### PR TITLE
fix(hooks): close three gaps found in review of the agent-attribution gate

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -13,14 +13,12 @@ scan="$repo_root/.github/scripts/agent-attribution-scan.sh"
 # Strip git's comment lines (those starting with '#') before inspecting.
 msg_body="$(grep -v '^#' "$msg_file" || true)"
 
-# Allow auto-generated messages (merge, revert, fixup!, squash!) through
-# untouched — they're produced by git itself and not authored prose.
 first_line="$(printf '%s\n' "$msg_body" | sed -n '1{/^$/d;p;q;}')"
-case "$first_line" in
-  Merge\ *|Revert\ *|fixup!\ *|squash!\ *|amend!\ *)
-    exit 0
-    ;;
-esac
+
+# NOTE: auto-generated subjects (Merge, Revert, fixup!, …) get no exemption
+# here. This repo does not enforce Conventional Commits, so the only rule left
+# is the attribution check — and a merge or a revert carries an author identity
+# and a co-author trailer like any other commit.
 
 fail() {
   printf '\ncommit-msg hook rejected this commit:\n\n  %s\n\n' "$1" >&2

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -37,7 +37,46 @@ while read -r local_ref local_sha remote_ref remote_sha; do
     # New branch on the remote. Scanning everything reachable from it would
     # re-flag the whole existing history, so scan only what this branch adds
     # that the remote does not already have somewhere.
-    set -- --rev-args "$local_sha" --not --remotes="$remote_name"
+    #
+    # The exclusions are taken from the remote's CURRENTLY ADVERTISED heads,
+    # not from this clone's cached refs/remotes/<remote>/*. A cached ref can
+    # name a branch that has since been deleted or force-pushed by someone
+    # else; excluding it would hide exactly the commits this hook exists to
+    # find — push a new branch carrying a commit only that stale ref covered,
+    # and the scan sees an empty set and passes. git has already contacted the
+    # remote to build this stdin, so the extra round trip is against a remote
+    # known to be reachable.
+    if ! advertised="$(git ls-remote --heads "$remote_name" 2>&1)"; then
+      printf '\npre-push hook: cannot list refs on %s.\n' "$remote_name" >&2
+      printf '%s\n' "$advertised" >&2
+      printf 'Without the remote ref list the scan cannot tell which commits this\n' >&2
+      printf 'branch actually adds, so it fails closed rather than guessing.\n\n' >&2
+      failed=1
+      continue
+    fi
+
+    set -- --rev-args "$local_sha"
+    unfetched=0
+    while read -r adv_sha _adv_ref; do
+      [ -n "$adv_sha" ] || continue
+      # A head we have never fetched cannot be used as an exclusion. Counting
+      # it and scanning wider is the fail-closed direction: worst case the hook
+      # reports commits the user did not write, and `git fetch` fixes that.
+      if git cat-file -e "${adv_sha}^{commit}" 2>/dev/null; then
+        set -- "$@" "^${adv_sha}"
+      else
+        unfetched=$((unfetched + 1))
+      fi
+    done <<ADVERTISED
+$advertised
+ADVERTISED
+
+    if [ "$unfetched" -gt 0 ]; then
+      printf 'pre-push hook: %d head(s) on %s are not in this clone, so the scan\n' \
+        "$unfetched" "$remote_name" >&2
+      printf 'covers more than strictly necessary. If it reports commits you did\n' >&2
+      printf 'not write, run "git fetch %s" and push again.\n' "$remote_name" >&2
+    fi
   else
     set -- --range "${remote_sha}..${local_sha}"
   fi

--- a/.github/scripts/agent-attribution-scan.sh
+++ b/.github/scripts/agent-attribution-scan.sh
@@ -58,8 +58,20 @@
 # compose-samples).
 set -uo pipefail
 
+# IDENTITY vocabulary — matched against a commit's author/committer fields. The
+# name is matched ANCHORED (see below), so it must stay a list of bare agent
+# names: a token that also occurs in human names would reject real people.
 AGENT_NAME='(claude|codex|chatgpt|copilot|gemini|cursor|devin|aider|jules)'
 AGENT_EMAIL='@(anthropic[.]com|openai[.]com|cursor[.](sh|com)|devin[.]ai|sourcegraph[.]com|continue[.]dev|factory[.]ai)'
+
+# TRAILER vocabulary — matched anywhere after `Co-authored-by:`. Deliberately
+# WIDER than the identity vocabulary, and it must stay that way: a trailer is
+# free-form text an agent writes about itself, so it carries product names and
+# vendor domains that never appear as a git identity. This is the list the
+# pre-existing workflow gates used; do not trim it without replacing the
+# coverage, or attribution the old gate rejected starts sailing through all
+# four layers at once.
+AGENT_TRAILER='(claude|anthropic[.]com|copilot|openai[.]com|chatgpt|codex|gemini|cursor[.](com|sh)|devin|aider|jules|sourcegraph[.]com|cody-ai|bard|sweep-ai|tabnine|codeium|continue[.]dev|replit-ai|amazonq|amazon-q|codewhisperer|qodo|bito-ai|cognition-ai|factory[.]ai|noreply@.*-ai|.*-bot@)'
 
 revs=()
 text_files=()
@@ -189,7 +201,7 @@ for f in ${text_files[@]+"${text_files[@]}"}; do
 done
 
 coauthor_hits="$(grep -iE '^[[:space:]]*Co-authored-by:' "$workdir/all_text.txt" \
-                 | grep -Ei "Co-authored-by:[[:space:]]*${AGENT_NAME}|${AGENT_EMAIL}" \
+                 | grep -Ei "Co-authored-by:.*${AGENT_TRAILER}" \
                  || true)"
 if [ -n "$coauthor_hits" ]; then
   problems="${problems}Agent Co-authored-by trailer(s):

--- a/scripts/test-agent-attribution.sh
+++ b/scripts/test-agent-attribution.sh
@@ -26,9 +26,12 @@ for f in "$SCAN" "$HOOK_COMMIT_MSG" "$HOOK_PRE_PUSH"; do
 done
 
 # The commit-msg hook enforces Conventional Commits in most of these repos but
-# not all of them; only assert it where the hook actually implements it.
+# not all of them; only assert it where the hook actually implements it. Detect
+# it by the rule itself, not by the words "Conventional Commits" — a hook that
+# merely explains why it does NOT enforce them would otherwise look like one
+# that does, and the suite would assert behaviour the hook never promised.
 enforces_conventional=0
-grep -q 'Conventional Commits' "$HOOK_COMMIT_MSG" && enforces_conventional=1
+grep -q '^conv_re=' "$HOOK_COMMIT_MSG" && enforces_conventional=1
 
 pass=0; fail=0
 check() { # check <label> <expected> <actual>
@@ -81,6 +84,26 @@ t 'feat: x\n\n\xf0\x9f\xa4\x96 Generated with Claude Code\nhttps://claude.ai/cod
 t 'docs: y\n\nWe reject a Co-authored-by: Claude <noreply@anthropic.com> trailer.\n'
                                                                         check "prose mentioning a trailer mid-line accepted" 0 $?
 
+# The trailer vocabulary is deliberately wider than the identity vocabulary and
+# must stay that way — these are the providers the pre-existing workflow gates
+# covered. Trimming the list silently reopens all four enforcement layers.
+t 'feat: x\n\nCo-authored-by: Tabnine <noreply@tabnine.com>\n';         check "Tabnine co-author rejected" 1 $?
+t 'feat: x\n\nCo-authored-by: Codeium <bot@codeium.com>\n';             check "Codeium co-author rejected" 1 $?
+t 'feat: x\n\nCo-authored-by: Amazon Q <amazonq@example.com>\n';        check "Amazon Q co-author rejected" 1 $?
+t 'feat: x\n\nCo-authored-by: CodeWhisperer <cw@example.com>\n';        check "CodeWhisperer co-author rejected" 1 $?
+t 'feat: x\n\nCo-authored-by: Cursor <bot@cursor.sh>\n';                check "Cursor co-author rejected" 1 $?
+t 'feat: x\n\nCo-authored-by: Cody <bot@sourcegraph.com>\n';            check "Sourcegraph Cody co-author rejected" 1 $?
+t 'feat: x\n\nCo-authored-by: copilot-swe-agent[bot] <1+Copilot@users.noreply.github.com>\n'
+                                                                        check "copilot-swe-agent[bot] co-author rejected" 1 $?
+t 'feat: x\n\nCo-authored-by: gemini-code-assist[bot] <1+gemini-code-assist[bot]@users.noreply.github.com>\n'
+                                                                        check "gemini-code-assist[bot] co-author rejected" 1 $?
+# ...but non-agent automation is NOT an agent. These land in history routinely
+# and must keep passing, or every dependency-bump merge trips the gate.
+t 'fix(deps): bump x\n\nCo-authored-by: renovate[bot] <29139614+renovate[bot]@users.noreply.github.com>\n'
+                                                                        check "renovate[bot] co-author accepted" 0 $?
+t 'chore: release\n\nCo-authored-by: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>\n'
+                                                                        check "github-actions[bot] co-author accepted" 0 $?
+
 echo
 echo "== commit-msg and pre-push hooks, end to end =="
 up="$tmp/upstream"; w="$tmp/clone"
@@ -106,6 +129,18 @@ git commit -q -m "feat: a" -m "Co-authored-by: Claude <noreply@anthropic.com>" >
 git -c user.name=Claude -c user.email=noreply@anthropic.com commit -q -m "feat: a" >/dev/null 2>&1
                                                 check "commit made AS an agent rejected" 1 $?
 git commit -q -m "feat: a" >/dev/null 2>&1;     check "same commit as a human accepted" 0 $?
+
+# Auto-generated subjects skip the Conventional Commits rule. They must NOT
+# skip the attribution scan — a merge or a revert carries an identity and a
+# trailer like any other commit.
+echo m >> f; git add -A
+git commit -q -m "Merge branch 'x'" -m "Co-authored-by: Claude <noreply@anthropic.com>" >/dev/null 2>&1
+                                                check "Merge subject does NOT skip the trailer scan" 1 $?
+git -c user.name=Claude -c user.email=noreply@anthropic.com \
+  commit -q -m "Revert \"feat: a\"" >/dev/null 2>&1
+                                                check "Revert subject does NOT skip the identity scan" 1 $?
+git commit -q -m "Merge branch 'x'" >/dev/null 2>&1
+                                                check "clean merge subject still accepted" 0 $?
 
 if [ "$enforces_conventional" -eq 1 ]; then
   echo b >> f; git add -A
@@ -142,6 +177,21 @@ echo g >> f; git add -A
 git commit -q --no-verify -m "feat: g" -m "Co-authored-by: Codex <codex@openai.com>"
 git push -q origin dirty-feature >/dev/null 2>&1
                                                 check "pre-push rejects a dirty NEW branch" 1 $?
+
+# Regression: a STALE remote-tracking ref must not be usable as an exclusion.
+# Put a dirty commit on the remote, cache the ref locally, delete the branch on
+# the remote — refs/remotes/origin/parked lingers. Pushing a new branch that
+# carries that commit must still be caught, even though the stale ref "covers"
+# it. Deriving exclusions from the cached --remotes namespace fails this.
+git checkout -q -b parked main
+echo s >> f; git add -A
+git commit -q --no-verify -m "feat: s" -m "Co-authored-by: Claude <noreply@anthropic.com>"
+git push -q --no-verify origin parked >/dev/null 2>&1
+git fetch -q origin
+git push -q --no-verify origin --delete parked >/dev/null 2>&1
+git checkout -q -b revived
+git push -q origin revived >/dev/null 2>&1
+                                                check "pre-push ignores a STALE remote-tracking ref" 1 $?
 
 echo
 printf '%d passed, %d failed\n' "$pass" "$fail"


### PR DESCRIPTION
Follow-up to #3. That merged before review of the identical change in the sibling repos (compose-ai-tools, meshcore-mobile, homeassistant-remotecompose) turned up three holes in the gate. Fixed here so all four stay byte-identical.

## 1. `pre-push` trusted stale remote-tracking refs (P1)

For a new branch, exclusions came from this clone's cached `refs/remotes/<remote>/*`. A tracking ref goes stale the moment someone else deletes or force-pushes that branch — and a stale ref still counts as "the remote already has this". Push a new branch carrying a commit that only that stale ref covered, and the scan saw an empty set and passed.

Exclusions now come from the remote's **currently advertised** heads via `git ls-remote`. git has already contacted the remote to build the hook's stdin, so this is a round trip against a remote known to be reachable; if it fails, the hook fails closed rather than guessing. Advertised heads not present in the clone can't be used as exclusions, so the scan widens rather than narrows, and says so.

## 2. The trailer vocabulary had silently shrunk (P1)

The detector used one vocabulary for both jobs, so folding the trailer check into the identity list dropped providers the sibling gates rejected — Tabnine, Codeium, Amazon Q, CodeWhisperer, Cody, Cursor.

Trailers now match a separate, deliberately wider `AGENT_TRAILER` list, with a comment saying why it must stay wider: a trailer is free-form text an agent writes about *itself*, so it carries product names and vendor domains that never appear as a git identity. The identity list stays narrow because it's matched anchored, where a loose token would reject real people.

Checked against every distinct `Co-authored-by:` trailer in this fork's history: it flags the three `gemini-code-assist[bot]` ones in upstream Google history and **none** of the 40+ human co-authors (Nick Butcher, Jolanda Verhoef, Ben Trengrove, …), nor `renovate[bot]` — automation, not an agent.

## 3. `commit-msg` waved through generated subjects (P2)

`Merge` / `Revert` / `fixup!` / `squash!` / `amend!` subjects returned early. In the siblings that skipped the attribution scan along with the Conventional Commits check; **here it skipped the only check the hook has**, since this repo deliberately doesn't enforce Conventional Commits. A merge or a revert carries an author identity and a co-author trailer like any other commit, so those subjects now get no exemption in this repo at all.

## Test plan

Each gap gets a regression test. `scripts/test-agent-attribution.sh` is 42 assertions here (44 in the siblings, which additionally assert the Conventional Commits rule), run by CI as the `self-test` job.

```
$ scripts/test-agent-attribution.sh
...
42 passed, 0 failed
```

New coverage: Tabnine / Codeium / Amazon Q / CodeWhisperer / Cursor / Cody / `copilot-swe-agent[bot]` / `gemini-code-assist[bot]` trailers rejected; `renovate[bot]` and `github-actions[bot]` trailers still accepted; a `Merge` subject not skipping the trailer scan and a `Revert` subject not skipping the identity scan; and a stale-remote-ref scenario built by pushing a dirty branch, caching its ref, deleting it on the remote, then pushing a new branch carrying that commit — which the old code accepted and the new code rejects.

Also fixes the suite's own detection of whether a hook enforces Conventional Commits: it grepped for the words, which this repo's hook now contains in a comment explaining that it does *not* enforce them.

No sample code touched — nothing in `Jetcaster/`, `Jetchat/`, `JetLagged/`, `JetNews/`, `Jetsnack/` or `Reply/` changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01N1MRxt2KnF2z4GzPGG3hqY)_