### PR TITLE
Avoid LocalLocale linkage failures in renderable samples

### DIFF
--- a/JetLagged/app/src/main/java/com/example/jetlagged/sleep/JetLaggedTimeGraph.kt
+++ b/JetLagged/app/src/main/java/com/example/jetlagged/sleep/JetLaggedTimeGraph.kt
@@ -36,7 +36,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.platform.LocalLocale
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.example.jetlagged.BasicInformationalCard
@@ -109,7 +108,7 @@ private fun JetLaggedTimeGraph(sleepGraphData: SleepGraphData, modifier: Modifie
 private fun DayLabel(dayOfWeek: DayOfWeek) {
     Text(
         dayOfWeek.getDisplayName(
-            TextStyle.SHORT, LocalLocale.current.platformLocale,
+            TextStyle.SHORT, Locale.getDefault(),
         ),
         Modifier
             .height(24.dp)

--- a/Jetsnack/app/src/main/java/com/example/jetsnack/ui/home/Home.kt
+++ b/Jetsnack/app/src/main/java/com/example/jetsnack/ui/home/Home.kt
@@ -60,7 +60,6 @@ import androidx.compose.ui.layout.MeasureScope
 import androidx.compose.ui.layout.Placeable
 import androidx.compose.ui.layout.layoutId
 import androidx.compose.ui.platform.LocalConfiguration
-import androidx.compose.ui.platform.LocalLocale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -188,7 +187,7 @@ fun JetsnackBottomBar(
         ) {
             val configuration = LocalConfiguration.current
             val currentLocale: Locale =
-                ConfigurationCompat.getLocales(configuration).get(0) ?: LocalLocale.current.platformLocale
+                ConfigurationCompat.getLocales(configuration).get(0) ?: Locale.getDefault()
 
             tabs.forEach { section ->
                 val selected = section == currentSection


### PR DESCRIPTION
### Motivation
- The preview renderer was failing with a missing linkage to `CompositionLocalsKt.getLocalLocale()` when rendering JetLagged, caused by using the Compose `LocalLocale` fallback in code paths executed in the preview/renderer.
- Replace the renderer-incompatible fallback with the JVM default locale so weekday names remain localized while avoiding the runtime linkage failure.

### Description
- In `JetLaggedTimeGraph.kt` replace `LocalLocale.current.platformLocale` with `Locale.getDefault()` and remove the unused `LocalLocale` import so day labels use the JVM default locale.
- In `Jetsnack`'s `Home.kt` change the fallback from `LocalLocale.current.platformLocale` to `Locale.getDefault()` and remove the `LocalLocale` import to prevent equivalent preview failures.
- Committed the changes as `Avoid LocalLocale in renderable samples` and ensured no Kotlin sources still reference `LocalLocale`.

### Testing
- Ran `JetLagged/gradlew -p JetLagged :app:compileDebugKotlin --no-daemon` which completed successfully.
- Ran `Jetsnack/gradlew -p Jetsnack :app:compileDebugKotlin --no-daemon` which completed successfully.
- Ran `git diff --check` and `rg -n 'LocalLocale' --glob '*.kt' .` to verify there are no remaining `LocalLocale` references and both checks passed.
- Fetched the preview server status via `curl https://preview.coo.ee/status` and confirmed the previously reported JetLagged render failure was recorded under Recent render failures before the fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a665765aec88324a52c692e1dd12146)