### PR TITLE
ci: auto-update preview tooling on previews

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,21 +1,21 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:base", ":dependencyDashboard"
-  ],
-  "dependencyDashboardApproval": true,
+  "extends": ["github>yschimke/renovate-config"],
+  "baseBranches": ["previews"],
+  "enabledManagers": ["gradle"],
   "packageRules": [
     {
-      "groupName": "Androidx Lifecycle deps",
-      "matchPackagePatterns": ["androidx.lifecycle", "androidx.navigation:navigation-compose"]
-    },
-     {
-      "groupName": "Compose Dependencies",
-      "matchPackagePatterns": "^androidx\\..*compose\\."
+      "description": "This branch only auto-updates the preview tooling used by the six catalogs.",
+      "matchDepNames": ["/.*/"],
+      "enabled": false
     },
     {
-      "groupName": "Kotlin Dependencies",
-      "matchPackagePrefixes": ["org.jetbrains.kotlin"]
+      "groupName": "compose-ai-tools",
+      "matchDepNames": [
+        "ee.schimke.composeai.preview",
+        "ee.schimke.composeai:preview-annotations"
+      ],
+      "enabled": true
     }
   ]
 }


### PR DESCRIPTION
Configure Renovate from the default branch so compose-ai-tools updates target the `previews` branch.\n\n- inherits the shared MeshCore Renovate preset and its green-CI automerge policy\n- limits updates to the compose preview Gradle plugin and preview annotations\n- groups all six sample catalogs into one update PR\n- leaves unrelated dependencies disabled\n\nThe same config is already committed on `previews` as f1bda7f2.