### PR TITLE
fix(jetcaster): scaffold Wear screen previews and unpin component previews

### DIFF
--- a/Jetcaster/catalog.wear.spec.json
+++ b/Jetcaster/catalog.wear.spec.json
@@ -217,11 +217,11 @@
         {
           "componentId": "Podcast/Content",
           "preview": "PodcastContentPreview",
-          "caption": "Podcast content block as laid out for a round display.",
+          "caption": "Podcast content block, centred at its on-device width rather than pinned to a screen.",
           "variants": [
             {
               "preview": "PodcastContentSmallCatalogPreview",
-              "caption": "Podcast content block on a small round display.",
+              "caption": "Podcast content block at the small-round width.",
               "props": {
                 "device": "smallRound"
               }
@@ -231,12 +231,12 @@
         {
           "componentId": "Player/Controls",
           "preview": "MediaContentPreview",
-          "caption": "Media content and transport on a round face — where Wear's touch-target minimums bite hardest.",
+          "caption": "Media content and transport, centred at its on-device width — where Wear's touch-target minimums bite hardest.",
           "parallel": "Player/Transport",
           "variants": [
             {
               "preview": "PlayerControlsSmallCatalogPreview",
-              "caption": "Media content and transport on a small round display.",
+              "caption": "Media content and transport at the small-round width.",
               "props": {
                 "device": "smallRound"
               }

--- a/Jetcaster/wear/src/debug/java/com/example/jetcaster/catalog/JetcasterWearCatalogPreviews.kt
+++ b/Jetcaster/wear/src/debug/java/com/example/jetcaster/catalog/JetcasterWearCatalogPreviews.kt
@@ -17,11 +17,9 @@
 package com.example.jetcaster.catalog
 
 import androidx.annotation.StringRes
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.wear.compose.foundation.lazy.rememberTransformingLazyColumnState
 import androidx.wear.compose.material3.AlertDialogContent
 import androidx.wear.compose.material3.Text
 import androidx.wear.compose.material3.rememberPlaceholderState
@@ -43,6 +41,8 @@ import com.example.jetcaster.ui.podcast.PodcastDetailsScreenState
 import com.example.jetcaster.ui.podcasts.PodcastScreenLoadedPreview
 import com.example.jetcaster.ui.podcasts.PodcastsScreen
 import com.example.jetcaster.ui.podcasts.PodcastsScreenState
+import com.example.jetcaster.ui.preview.JetcasterListScreenPreview
+import com.example.jetcaster.ui.preview.JetcasterScreenPreview
 import com.example.jetcaster.ui.preview.JetcasterWearLargeRoundPreview
 import com.example.jetcaster.ui.preview.JetcasterWearSmallRoundPreview
 import com.example.jetcaster.ui.queue.QueueScreen
@@ -57,12 +57,14 @@ fun PodcastScreenSmallCatalogPreview() = PodcastScreenLoadedPreview()
 
 @JetcasterWearLargeRoundPreview
 @Composable
-fun PodcastScreenLoadingCatalogPreview() = PodcastsScreen(
-    podcastsScreenState = PodcastsScreenState.Loading,
-    placeholderState = rememberPlaceholderState(isVisible = true),
-    onPodcastsItemClick = {},
-    onDismiss = {},
-)
+fun PodcastScreenLoadingCatalogPreview() = JetcasterScreenPreview {
+    PodcastsScreen(
+        podcastsScreenState = PodcastsScreenState.Loading,
+        placeholderState = rememberPlaceholderState(isVisible = true),
+        onPodcastsItemClick = {},
+        onDismiss = {},
+    )
+}
 
 @JetcasterWearLargeRoundPreview
 @Composable
@@ -74,14 +76,16 @@ fun PodcastDetailsSmallCatalogPreview() = PodcastDetailsScreenLoadedPreview()
 
 @JetcasterWearLargeRoundPreview
 @Composable
-fun PodcastDetailsLoadingCatalogPreview() = PodcastDetailsScreen(
-    uiState = PodcastDetailsScreenState.Loading,
-    placeholderState = rememberPlaceholderState(isVisible = true),
-    onPlayButtonClick = {},
-    onEpisodeItemClick = {},
-    onPlayEpisode = {},
-    onDismiss = {},
-)
+fun PodcastDetailsLoadingCatalogPreview() = JetcasterScreenPreview {
+    PodcastDetailsScreen(
+        uiState = PodcastDetailsScreenState.Loading,
+        placeholderState = rememberPlaceholderState(isVisible = true),
+        onPlayButtonClick = {},
+        onEpisodeItemClick = {},
+        onPlayEpisode = {},
+        onDismiss = {},
+    )
+}
 
 @JetcasterWearLargeRoundPreview
 @Composable
@@ -97,24 +101,28 @@ fun LibraryScreenSmallCatalogPreview() = LibraryScreenPreview()
 
 @JetcasterWearLargeRoundPreview
 @Composable
-fun LibraryScreenLoadingCatalogPreview() = LibraryScreen(
-    columnState = rememberTransformingLazyColumnState(),
-    contentPadding = PaddingValues(),
-    onLatestEpisodeClick = {},
-    onYourPodcastClick = {},
-    onUpNextClick = {},
-    placeholderState = rememberPlaceholderState(isVisible = true),
-    queue = emptyList(),
-)
+fun LibraryScreenLoadingCatalogPreview() = JetcasterListScreenPreview { columnState, contentPadding ->
+    LibraryScreen(
+        columnState = columnState,
+        contentPadding = contentPadding,
+        onLatestEpisodeClick = {},
+        onYourPodcastClick = {},
+        onUpNextClick = {},
+        placeholderState = rememberPlaceholderState(isVisible = true),
+        queue = emptyList(),
+    )
+}
 
 @JetcasterWearLargeRoundPreview
 @Composable
-fun LibraryScreenNoSubscriptionsCatalogPreview() = NoSubscribedPodcastScreen(
-    columnState = rememberTransformingLazyColumnState(),
-    contentPadding = PaddingValues(),
-    topPodcasts = PreviewPodcasts,
-    onTogglePodcastFollowed = {},
-)
+fun LibraryScreenNoSubscriptionsCatalogPreview() = JetcasterListScreenPreview { columnState, contentPadding ->
+    NoSubscribedPodcastScreen(
+        columnState = columnState,
+        contentPadding = contentPadding,
+        topPodcasts = PreviewPodcasts,
+        onTogglePodcastFollowed = {},
+    )
+}
 
 @JetcasterWearSmallRoundPreview
 @Composable
@@ -122,14 +130,16 @@ fun LatestEpisodeSmallCatalogPreview() = LatestEpisodeScreenLoadedPreview()
 
 @JetcasterWearLargeRoundPreview
 @Composable
-fun LatestEpisodeLoadingCatalogPreview() = LatestEpisodeScreen(
-    uiState = LatestEpisodeScreenState.Loading,
-    placeholderState = rememberPlaceholderState(isVisible = true),
-    onPlayButtonClick = {},
-    onDismiss = {},
-    onPlayEpisodes = {},
-    onPlayEpisode = {},
-)
+fun LatestEpisodeLoadingCatalogPreview() = JetcasterScreenPreview {
+    LatestEpisodeScreen(
+        uiState = LatestEpisodeScreenState.Loading,
+        placeholderState = rememberPlaceholderState(isVisible = true),
+        onPlayButtonClick = {},
+        onDismiss = {},
+        onPlayEpisodes = {},
+        onPlayEpisode = {},
+    )
+}
 
 @JetcasterWearLargeRoundPreview
 @Composable
@@ -153,15 +163,17 @@ fun QueueScreenSmallCatalogPreview() = QueueScreenLoadedPreview()
 
 @JetcasterWearLargeRoundPreview
 @Composable
-fun QueueScreenLoadingCatalogPreview() = QueueScreen(
-    uiState = QueueScreenState.Loading,
-    placeholderState = rememberPlaceholderState(isVisible = true),
-    onPlayButtonClick = {},
-    onPlayEpisodes = {},
-    onEpisodeItemClick = {},
-    onDeleteQueueEpisodes = {},
-    onDismiss = {},
-)
+fun QueueScreenLoadingCatalogPreview() = JetcasterScreenPreview {
+    QueueScreen(
+        uiState = QueueScreenState.Loading,
+        placeholderState = rememberPlaceholderState(isVisible = true),
+        onPlayButtonClick = {},
+        onPlayEpisodes = {},
+        onEpisodeItemClick = {},
+        onDeleteQueueEpisodes = {},
+        onDismiss = {},
+    )
+}
 
 @JetcasterWearLargeRoundPreview
 @Composable
@@ -202,12 +214,14 @@ fun PlayerControlsLargestFontCatalogPreview() = MediaContentPreview()
 
 @Composable
 private fun WearEmptyDialogCatalogPreview(@StringRes titleRes: Int, @StringRes textRes: Int? = null) {
-    if (textRes == null) {
-        AlertDialogContent(title = { Text(stringResource(titleRes)) })
-    } else {
-        AlertDialogContent(
-            title = { Text(stringResource(titleRes)) },
-            text = { Text(stringResource(textRes)) },
-        )
+    JetcasterScreenPreview {
+        if (textRes == null) {
+            AlertDialogContent(title = { Text(stringResource(titleRes)) })
+        } else {
+            AlertDialogContent(
+                title = { Text(stringResource(titleRes)) },
+                text = { Text(stringResource(textRes)) },
+            )
+        }
     }
 }

--- a/Jetcaster/wear/src/main/java/com/example/jetcaster/ui/components/MediaContent.kt
+++ b/Jetcaster/wear/src/main/java/com/example/jetcaster/ui/components/MediaContent.kt
@@ -16,9 +16,7 @@
 
 package com.example.jetcaster.ui.components
 
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
@@ -29,17 +27,16 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.wear.compose.material3.AppScaffold
 import androidx.wear.compose.material3.ButtonDefaults
 import androidx.wear.compose.material3.FilledTonalButton
-import androidx.wear.compose.material3.ScreenScaffold
 import androidx.wear.compose.material3.SurfaceTransformation
 import androidx.wear.compose.material3.Text
 import coil.compose.AsyncImage
 import com.example.jetcaster.R
 import com.example.jetcaster.core.domain.testing.PreviewPlayerEpisodes
-import com.example.jetcaster.ui.preview.JetcasterWearLargeRoundPreview
 import com.example.jetcaster.core.player.model.PlayerEpisode
+import com.example.jetcaster.ui.preview.JetcasterComponentPreview
+import com.example.jetcaster.ui.preview.JetcasterWearLargeRoundPreview
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
 
@@ -104,22 +101,15 @@ fun MediaContent(
     )
 }
 
+// A single media row is a component, not a screen: framing it with `JetcasterComponentPreview`
+// centres it at its on-device width instead of hanging it off the top of a `ScreenScaffold`, where
+// the round display clipped the row.
 @JetcasterWearLargeRoundPreview
 @Composable
 fun MediaContentPreview() {
     val episode = PreviewPlayerEpisodes.first()
-    AppScaffold(modifier = Modifier) {
-        ScreenScaffold { contentPadding ->
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(contentPadding),
-            ) {
-                MediaContent(
-                    episode, onItemClick = { null },
-                )
-            }
-        }
+    JetcasterComponentPreview {
+        MediaContent(episode, onItemClick = { null })
     }
 }
 

--- a/Jetcaster/wear/src/main/java/com/example/jetcaster/ui/episode/EpisodeScreen.kt
+++ b/Jetcaster/wear/src/main/java/com/example/jetcaster/ui/episode/EpisodeScreen.kt
@@ -60,10 +60,12 @@ import androidx.wear.compose.material3.rememberPlaceholderState
 import com.example.jetcaster.R
 import com.example.jetcaster.core.domain.testing.PreviewPlayerEpisodes
 import com.example.jetcaster.core.player.model.PlayerEpisode
-import com.example.jetcaster.ui.preview.JetcasterWearLargeRoundPreview
 import com.example.jetcaster.core.player.model.toPlayerEpisode
 import com.example.jetcaster.designsystem.component.HtmlTextContainer
 import com.example.jetcaster.ui.components.MediumDateFormatter
+import com.example.jetcaster.ui.preview.JetcasterListScreenPreview
+import com.example.jetcaster.ui.preview.JetcasterScreenPreview
+import com.example.jetcaster.ui.preview.JetcasterWearLargeRoundPreview
 
 @Composable
 fun EpisodeScreen(
@@ -320,46 +322,50 @@ private fun TransformingLazyColumnScope.episodeInfoContent(episode: PlayerEpisod
 @Composable
 fun EpisodeScreenEmptyPreview() {
     val uiState: EpisodeScreenState = EpisodeScreenState.Empty
-    EpisodeScreen(
-        uiState = uiState,
-        onPlayButtonClick = { },
-        onPlayEpisode = { _ -> },
-        onAddToQueue = { _ -> },
-        onDismiss = {},
-        placeholderState = rememberPlaceholderState(isVisible = true),
-    )
+    JetcasterScreenPreview {
+        EpisodeScreen(
+            uiState = uiState,
+            onPlayButtonClick = { },
+            onPlayEpisode = { _ -> },
+            onAddToQueue = { _ -> },
+            onDismiss = {},
+            placeholderState = rememberPlaceholderState(isVisible = true),
+        )
+    }
 }
 
 @JetcasterWearLargeRoundPreview
 @Composable
 fun EpisodeScreenLoadingPreview() {
     val episode = PreviewPlayerEpisodes.first()
-    val columnState = rememberTransformingLazyColumnState()
-    EpisodeScreenLoaded(
-        title = episode.title,
-        episode = episode,
-        onPlayButtonClick = { },
-        onPlayEpisode = { },
-        onAddToQueue = { },
-        columnState = columnState,
-        contentPadding = PaddingValues(),
-        placeholderState = rememberPlaceholderState(isVisible = true),
-    )
+    JetcasterListScreenPreview { columnState, contentPadding ->
+        EpisodeScreenLoaded(
+            title = episode.title,
+            episode = episode,
+            onPlayButtonClick = { },
+            onPlayEpisode = { },
+            onAddToQueue = { },
+            columnState = columnState,
+            contentPadding = contentPadding,
+            placeholderState = rememberPlaceholderState(isVisible = true),
+        )
+    }
 }
 
 @JetcasterWearLargeRoundPreview
 @Composable
 fun EpisodeScreenLoadedPreview() {
     val episode = PreviewPlayerEpisodes.first()
-    val columnState = rememberTransformingLazyColumnState()
-    EpisodeScreenLoaded(
-        title = episode.title,
-        episode = episode,
-        onPlayButtonClick = { },
-        onPlayEpisode = { },
-        onAddToQueue = { },
-        columnState = columnState,
-        contentPadding = PaddingValues(),
-        placeholderState = rememberPlaceholderState(isVisible = false),
-    )
+    JetcasterListScreenPreview { columnState, contentPadding ->
+        EpisodeScreenLoaded(
+            title = episode.title,
+            episode = episode,
+            onPlayButtonClick = { },
+            onPlayEpisode = { },
+            onAddToQueue = { },
+            columnState = columnState,
+            contentPadding = contentPadding,
+            placeholderState = rememberPlaceholderState(isVisible = false),
+        )
+    }
 }

--- a/Jetcaster/wear/src/main/java/com/example/jetcaster/ui/latest_episodes/LatestEpisodesScreen.kt
+++ b/Jetcaster/wear/src/main/java/com/example/jetcaster/ui/latest_episodes/LatestEpisodesScreen.kt
@@ -48,8 +48,9 @@ import androidx.wear.compose.material3.rememberPlaceholderState
 import com.example.jetcaster.R
 import com.example.jetcaster.core.domain.testing.PreviewPlayerEpisodes
 import com.example.jetcaster.core.player.model.PlayerEpisode
-import com.example.jetcaster.ui.preview.JetcasterWearLargeRoundPreview
 import com.example.jetcaster.ui.components.MediaContent
+import com.example.jetcaster.ui.preview.JetcasterListScreenPreview
+import com.example.jetcaster.ui.preview.JetcasterWearLargeRoundPreview
 
 @Composable fun LatestEpisodesScreen(
     onPlayButtonClick: () -> Unit,
@@ -234,14 +235,15 @@ fun LatestEpisodesListHeader(
 @Composable
 fun LatestEpisodeScreenLoadedPreview() {
     val episode = PreviewPlayerEpisodes.first()
-    val columnState = rememberTransformingLazyColumnState()
-    LatestEpisodesScreen(
-        episodeList = listOf(episode),
-        onPlayButtonClick = { },
-        onPlayEpisode = { },
-        onPlayEpisodes = { },
-        contentPadding = PaddingValues(),
-        scrollState = columnState,
-        placeholderState = rememberPlaceholderState(isVisible = false),
-    )
+    JetcasterListScreenPreview { columnState, contentPadding ->
+        LatestEpisodesScreen(
+            episodeList = listOf(episode),
+            onPlayButtonClick = { },
+            onPlayEpisode = { },
+            onPlayEpisodes = { },
+            contentPadding = contentPadding,
+            scrollState = columnState,
+            placeholderState = rememberPlaceholderState(isVisible = false),
+        )
+    }
 }

--- a/Jetcaster/wear/src/main/java/com/example/jetcaster/ui/library/LibraryScreen.kt
+++ b/Jetcaster/wear/src/main/java/com/example/jetcaster/ui/library/LibraryScreen.kt
@@ -20,7 +20,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
@@ -40,7 +39,6 @@ import androidx.wear.compose.foundation.lazy.TransformingLazyColumn
 import androidx.wear.compose.foundation.lazy.TransformingLazyColumnState
 import androidx.wear.compose.foundation.lazy.items
 import androidx.wear.compose.foundation.lazy.rememberTransformingLazyColumnState
-import androidx.wear.compose.material3.AppScaffold
 import androidx.wear.compose.material3.ButtonDefaults
 import androidx.wear.compose.material3.FilledTonalButton
 import androidx.wear.compose.material3.Icon
@@ -61,9 +59,11 @@ import coil.compose.AsyncImage
 import com.example.jetcaster.R
 import com.example.jetcaster.core.domain.testing.PreviewPlayerEpisodes
 import com.example.jetcaster.core.domain.testing.PreviewPodcasts
-import com.example.jetcaster.ui.preview.JetcasterWearLargeRoundPreview
 import com.example.jetcaster.core.model.PodcastInfo
 import com.example.jetcaster.core.player.model.PlayerEpisode
+import com.example.jetcaster.ui.preview.JetcasterComponentPreview
+import com.example.jetcaster.ui.preview.JetcasterListScreenPreview
+import com.example.jetcaster.ui.preview.JetcasterWearLargeRoundPreview
 
 @Composable
 fun LibraryScreen(
@@ -360,36 +360,33 @@ private fun QueueEmptyText(modifier: Modifier = Modifier) {
 @JetcasterWearLargeRoundPreview
 @Composable
 fun LibraryScreenPreview() {
-    LibraryScreen(
-        columnState = rememberTransformingLazyColumnState(),
-        contentPadding = PaddingValues(),
-        modifier = Modifier,
-        onLatestEpisodeClick = {},
-        onYourPodcastClick = {},
-        onUpNextClick = {},
-        queue = listOf(
-            PreviewPlayerEpisodes.first(),
-        ),
-        placeholderState = rememberPlaceholderState(isVisible = false),
-    )
+    JetcasterListScreenPreview { columnState, contentPadding ->
+        LibraryScreen(
+            columnState = columnState,
+            contentPadding = contentPadding,
+            modifier = Modifier,
+            onLatestEpisodeClick = {},
+            onYourPodcastClick = {},
+            onUpNextClick = {},
+            queue = listOf(
+                PreviewPlayerEpisodes.first(),
+            ),
+            placeholderState = rememberPlaceholderState(isVisible = false),
+        )
+    }
 }
 
+// `PodcastContent` is a component, not a screen, so it is framed by
+// `JetcasterComponentPreview` — centred at its on-device width — rather than pinned to the top of
+// an `AppScaffold`/`ScreenScaffold`, where the round bezel clipped it.
 @JetcasterWearLargeRoundPreview
 @Composable
 fun PodcastContentPreview() {
-    AppScaffold {
-        ScreenScaffold {
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(it),
-            ) {
-                PodcastContent(
-                    podcast = PreviewPodcasts.first(),
-                    podcastArtworkPlaceholder = painterResource(id = R.drawable.music),
-                    onClick = {},
-                )
-            }
-        }
+    JetcasterComponentPreview {
+        PodcastContent(
+            podcast = PreviewPodcasts.first(),
+            podcastArtworkPlaceholder = painterResource(id = R.drawable.music),
+            onClick = {},
+        )
     }
 }

--- a/Jetcaster/wear/src/main/java/com/example/jetcaster/ui/podcast/PodcastDetailsScreen.kt
+++ b/Jetcaster/wear/src/main/java/com/example/jetcaster/ui/podcast/PodcastDetailsScreen.kt
@@ -46,11 +46,12 @@ import androidx.wear.compose.material3.placeholder
 import androidx.wear.compose.material3.placeholderShimmer
 import androidx.wear.compose.material3.rememberPlaceholderState
 import com.example.jetcaster.R
-import com.example.jetcaster.core.domain.testing.PreviewPodcastEpisodes
 import com.example.jetcaster.core.domain.testing.PreviewPlayerEpisodes
-import com.example.jetcaster.ui.preview.JetcasterWearLargeRoundPreview
+import com.example.jetcaster.core.domain.testing.PreviewPodcastEpisodes
 import com.example.jetcaster.core.player.model.PlayerEpisode
 import com.example.jetcaster.ui.components.MediaContent
+import com.example.jetcaster.ui.preview.JetcasterScreenPreview
+import com.example.jetcaster.ui.preview.JetcasterWearLargeRoundPreview
 
 @Composable fun PodcastDetailsScreen(
     onPlayButtonClick: () -> Unit,
@@ -225,15 +226,17 @@ fun ButtonsContent(
 @Composable
 fun PodcastDetailsScreenLoadedPreview() {
     val episode = PreviewPlayerEpisodes.first()
-    PodcastDetailsScreen(
-        uiState = PodcastDetailsScreenState.Loaded(
-            episodeList = listOf(episode),
-            podcast = PreviewPodcastEpisodes.first().podcast,
-        ),
-        onPlayButtonClick = { },
-        onEpisodeItemClick = {},
-        onPlayEpisode = {},
-        onDismiss = {},
-        placeholderState = rememberPlaceholderState(isVisible = false),
-    )
+    JetcasterScreenPreview {
+        PodcastDetailsScreen(
+            uiState = PodcastDetailsScreenState.Loaded(
+                episodeList = listOf(episode),
+                podcast = PreviewPodcastEpisodes.first().podcast,
+            ),
+            onPlayButtonClick = { },
+            onEpisodeItemClick = {},
+            onPlayEpisode = {},
+            onDismiss = {},
+            placeholderState = rememberPlaceholderState(isVisible = false),
+        )
+    }
 }

--- a/Jetcaster/wear/src/main/java/com/example/jetcaster/ui/podcasts/PodcastsScreen.kt
+++ b/Jetcaster/wear/src/main/java/com/example/jetcaster/ui/podcasts/PodcastsScreen.kt
@@ -52,8 +52,10 @@ import androidx.wear.compose.material3.rememberPlaceholderState
 import coil.compose.AsyncImage
 import com.example.jetcaster.R
 import com.example.jetcaster.core.domain.testing.PreviewPodcasts
-import com.example.jetcaster.ui.preview.JetcasterWearLargeRoundPreview
 import com.example.jetcaster.core.model.PodcastInfo
+import com.example.jetcaster.ui.preview.JetcasterListScreenPreview
+import com.example.jetcaster.ui.preview.JetcasterScreenPreview
+import com.example.jetcaster.ui.preview.JetcasterWearLargeRoundPreview
 
 @Composable
 fun PodcastsScreen(
@@ -225,17 +227,18 @@ fun MediaContent(
 @JetcasterWearLargeRoundPreview
 @Composable
 fun PodcastScreenLoadedPreview() {
-    val columnState = rememberTransformingLazyColumnState()
-    PodcastScreenLoaded(
-        podcastList = listOf(PreviewPodcasts.first()),
-        onPodcastsItemClick = {},
-        contentPadding = PaddingValues(),
-        columnState = columnState,
-        placeholderState = rememberPlaceholderState(isVisible = false),
-    )
+    JetcasterListScreenPreview { columnState, contentPadding ->
+        PodcastScreenLoaded(
+            podcastList = listOf(PreviewPodcasts.first()),
+            onPodcastsItemClick = {},
+            contentPadding = contentPadding,
+            columnState = columnState,
+            placeholderState = rememberPlaceholderState(isVisible = false),
+        )
+    }
 }
 
 @Composable
 fun PodcastScreenEmptyPreview() {
-    PodcastScreenEmpty(onDismiss = {})
+    JetcasterScreenPreview { PodcastScreenEmpty(onDismiss = {}) }
 }

--- a/Jetcaster/wear/src/main/java/com/example/jetcaster/ui/preview/JetcasterWearPreviewScaffolds.kt
+++ b/Jetcaster/wear/src/main/java/com/example/jetcaster/ui/preview/JetcasterWearPreviewScaffolds.kt
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.jetcaster.ui.preview
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.wear.compose.foundation.lazy.TransformingLazyColumnState
+import androidx.wear.compose.foundation.lazy.rememberTransformingLazyColumnState
+import androidx.wear.compose.material3.AppScaffold
+import androidx.wear.compose.material3.ScreenScaffold
+import androidx.wear.compose.material3.TimeSource
+import androidx.wear.compose.material3.TimeText
+import com.example.jetcaster.theme.WearAppTheme
+
+/**
+ * A clock frozen at 10:10 for previews.
+ *
+ * The running app lets [TimeText] read the system clock; a preview must not, or every render of the
+ * catalog differs from the last one by whatever the wall-clock happened to be, and the design
+ * artifacts churn on nothing.
+ */
+object FixedPreviewTimeSource : TimeSource {
+    @Composable
+    override fun currentTime(): String = "10:10"
+}
+
+/**
+ * The frame for a **screen** preview: Jetcaster's Wear theme plus the `AppScaffold` that
+ * [com.example.jetcaster.WearApp] supplies at the top of the running app, with the curved
+ * [TimeText] status strip frozen by [FixedPreviewTimeSource].
+ *
+ * Use this for a screen that composes its own `ScreenScaffold` (the whole-screen entry points:
+ * `EpisodeScreen`, `QueueScreen`, `PodcastDetailsScreen`, …). Without the `AppScaffold` a screen
+ * preview renders with no status strip at all — not what the screen looks like on a watch, and it
+ * over-reports the vertical space the content actually gets.
+ */
+@Composable
+fun JetcasterScreenPreview(content: @Composable () -> Unit) {
+    WearAppTheme {
+        AppScaffold(timeText = { TimeText(timeSource = FixedPreviewTimeSource) }) { content() }
+    }
+}
+
+/**
+ * The frame for a **list screen** preview whose content is the inner, already-hoisted composable
+ * that takes a scroll state and the scaffold's content padding (`PodcastScreenLoaded`,
+ * `EpisodeScreenLoaded`, `QueueScreenLoaded`, `LibraryScreen`, `LatestEpisodesScreen`).
+ *
+ * It supplies the same `AppScaffold` + frozen `TimeText` as [JetcasterScreenPreview] plus the
+ * `ScreenScaffold` the production caller would have wrapped the content in, and hands the content
+ * the real scroll state and content padding. Previews used to pass `PaddingValues()` and a bare
+ * `rememberTransformingLazyColumnState()` here, which dropped both the status strip and the curved
+ * top/bottom insets — so the first list item rendered jammed against the top of the round display
+ * where the bezel clips it.
+ */
+@Composable
+fun JetcasterListScreenPreview(content: @Composable (columnState: TransformingLazyColumnState, contentPadding: PaddingValues) -> Unit) {
+    JetcasterScreenPreview {
+        val columnState = rememberTransformingLazyColumnState()
+        ScreenScaffold(scrollState = columnState) { contentPadding ->
+            content(columnState, contentPadding)
+        }
+    }
+}
+
+/**
+ * The frame for a **component** preview: the theme and nothing else, with the component centred on
+ * the round face inside the Wear horizontal margin.
+ *
+ * Deliberately *not* a screen: a lone component hosted in an `AppScaffold`/`ScreenScaffold` lands at
+ * the very top of the round display, where the curved edge clips it and the status strip crowds it
+ * — the capture then reads as a broken screen rather than as the component. Centring it, with the
+ * side margin a Wear list item would get, shows the component whole at the width it really has on
+ * the device.
+ */
+@Composable
+fun JetcasterComponentPreview(content: @Composable () -> Unit) {
+    WearAppTheme {
+        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            Box(modifier = Modifier.fillMaxWidth(WEAR_COMPONENT_WIDTH_FRACTION)) { content() }
+        }
+    }
+}
+
+/**
+ * The fraction of the display width a Wear list item spans — the Material 3 5.2% side margin taken
+ * off each edge. Applied to a [JetcasterComponentPreview] so a `fillMaxWidth` component measures at
+ * its on-device width instead of running edge to edge into the bezel.
+ */
+private const val WEAR_COMPONENT_WIDTH_FRACTION = 0.896f

--- a/Jetcaster/wear/src/main/java/com/example/jetcaster/ui/queue/QueueScreen.kt
+++ b/Jetcaster/wear/src/main/java/com/example/jetcaster/ui/queue/QueueScreen.kt
@@ -57,8 +57,10 @@ import androidx.wear.compose.material3.rememberPlaceholderState
 import com.example.jetcaster.R
 import com.example.jetcaster.core.domain.testing.PreviewPlayerEpisodes
 import com.example.jetcaster.core.player.model.PlayerEpisode
-import com.example.jetcaster.ui.preview.JetcasterWearLargeRoundPreview
 import com.example.jetcaster.ui.components.MediaContent
+import com.example.jetcaster.ui.preview.JetcasterListScreenPreview
+import com.example.jetcaster.ui.preview.JetcasterScreenPreview
+import com.example.jetcaster.ui.preview.JetcasterWearLargeRoundPreview
 
 @Composable fun QueueScreen(
     onPlayButtonClick: () -> Unit,
@@ -261,20 +263,21 @@ fun ButtonsContent(
 @Composable
 fun QueueScreenLoadedPreview() {
     val episode = PreviewPlayerEpisodes.first()
-    val columnState = rememberTransformingLazyColumnState()
-    QueueScreenLoaded(
-        episodeList = listOf(episode),
-        onPlayButtonClick = { },
-        onPlayEpisodes = { },
-        onDeleteQueueEpisodes = { },
-        onEpisodeItemClick = { },
-        columnState = columnState,
-        contentPadding = PaddingValues(),
-        placeholderState = rememberPlaceholderState(isVisible = false),
-    )
+    JetcasterListScreenPreview { columnState, contentPadding ->
+        QueueScreenLoaded(
+            episodeList = listOf(episode),
+            onPlayButtonClick = { },
+            onPlayEpisodes = { },
+            onDeleteQueueEpisodes = { },
+            onEpisodeItemClick = { },
+            columnState = columnState,
+            contentPadding = contentPadding,
+            placeholderState = rememberPlaceholderState(isVisible = false),
+        )
+    }
 }
 
 @Composable
 fun QueueScreenEmptyPreview() {
-    QueueScreenEmpty(onDismiss = {})
+    JetcasterScreenPreview { QueueScreenEmpty(onDismiss = {}) }
 }


### PR DESCRIPTION
## Summary

Two problems made the Jetcaster Wear catalog's captures misrepresent the app.

**Screens rendered with no status strip.** Production puts `AppScaffold` at the root (`WearApp`) and lets each screen own its `ScreenScaffold`. The previews called the screen directly — or, worse, called the inner already-hoisted content with `contentPadding = PaddingValues()` and a bare column state. So they lost the curved `TimeText` *and* the scaffold's top/bottom insets, and the first list item rendered jammed against the top of the round display. They now go through `JetcasterScreenPreview` / `JetcasterListScreenPreview`, which supply the app theme, the `AppScaffold` with a `TimeText` frozen at 10:10, and the real `ScreenScaffold` content padding.

**Components were hosted on screen layouts and clipped.** `MediaContentPreview` and `PodcastContentPreview` pinned a single full-width row to the top of an `AppScaffold`/`ScreenScaffold`, where the round bezel cut its ends off and the live system clock sat above it — a broken screen, not a component. `JetcasterComponentPreview` centres them at their on-device width with no screen scaffolding at all.

Two side effects worth calling out: every preview now picks up `WearAppTheme` (they previously rendered against the default M3 purple), and the clock is deterministic, so the design-artifacts bundle stops churning on wall-clock time.

New file: `ui/preview/JetcasterWearPreviewScaffolds.kt` holds the three frames plus `FixedPreviewTimeSource`. Captions for the two component entries in `catalog.wear.spec.json` were updated to match.

## Visual evidence

Two screens and the two components, large round:

**Before** — screens have no clock and no scaffold insets; components clipped by the bezel under a live 9:44 clock:

![before](https://raw.githubusercontent.com/yschimke/compose-ai-tools/298632f079bfc6680faaaff6c97a69dbbf503f5e/renders/jetcaster-wear-before.png)

**After** — screens carry the frozen curved TimeText and real content padding; components centred, whole, at their on-device width:

![after](https://raw.githubusercontent.com/yschimke/compose-ai-tools/298632f079bfc6680faaaff6c97a69dbbf503f5e/renders/jetcaster-wear-after.png)

(Images hosted on the companion `yschimke/compose-ai-tools` branch, commit-pinned; this repo keeps rendered PNGs on the `previews` branch rather than in the source tree.)

## Test plan

- `./gradlew :wear:composePreviewRenderAll` — rendered end-to-end in-session against a local Android SDK. All 33 preview PNGs regenerated and were reviewed; the one pre-existing failure (`activity__MainActivity`, Hilt `@HiltAndroidApp` requirement) reproduces unchanged on the base branch and is untouched by this change.
- `./gradlew :wear:compileDebugKotlin` — BUILD SUCCESSFUL.
- `./gradlew :wear:spotlessCheck` — BUILD SUCCESSFUL.

## Related

Companion PR yschimke/compose-ai-tools#2889 applies the same status-strip fix to the `design-catalog-wear-m3` catalog.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Byenj6ZMCUHeDr4eYpe66w)_