### PR TITLE
ci: automerge the compose-ai-tools bump on previews

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,12 +10,14 @@
       "enabled": false
     },
     {
+      "description": "compose-ai-tools ships the ee.schimke.composeai.preview Gradle plugin and the preview-annotations artifact as one release, and that release IS the renderer behind the published catalogs — the samples' own UI code is upstream Google's and barely moves, so a stale pin here is the main way /jetnews, /jetcaster & co. go stale. Automerge once CI on `previews` is green: design-artifacts.yml already re-renders and republishes every delivery branch on push to `previews` whenever */gradle/libs.versions.toml moves, and a Renovate merge is made with the app's token, which does raise `push` — so the bump lands and the catalogs regenerate with nobody in the loop. platformAutomerge stays false via the shared preset, so Renovate waits for every check instead of merging ahead of them. Deliberately left on the preset's weekly schedule rather than `at any time` (which cadence / meshcore-mobile / homeassistant-remotecompose use): a republish here is seven systems x re-theme + publish, and compose-ai-tools releases several times a day.",
       "groupName": "compose-ai-tools",
       "matchDepNames": [
         "ee.schimke.composeai.preview",
         "ee.schimke.composeai:preview-annotations"
       ],
-      "enabled": true
+      "enabled": true,
+      "automerge": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds `"automerge": true` to the `compose-ai-tools` group in `renovate.json`, so the preview-tooling bump on `previews` lands without anyone merging it.

Everything else in the chain is already wired: `design-artifacts.yml` republishes all seven delivery branches on push to `previews` when `*/gradle/libs.versions.toml` moves, and Renovate merges with the app's token, which **does** raise `push`. So automerge is the only missing link between "a new compose-ai-tools release exists" and "the published catalogs are rendered by it". That matters more here than in the sibling repos: the sample UI is upstream Google's and barely moves, so a stale pin is essentially the only way `/jetnews`, `/jetcaster` & co. go stale.

`platformAutomerge` stays `false` via the shared `github>yschimke/renovate-config` preset, so Renovate waits for every check on the branch rather than handing the PR to GitHub's native auto-merge (which only waits for checks branch protection marks *required*).

Deliberately **not** adding `"schedule": ["at any time"]` the way cadence / meshcore-mobile / homeassistant-remotecompose do — the group stays in the preset's weekly window. A republish here is seven systems × (re-theme + publish) and compose-ai-tools releases several times a day; weekly is the right cost here. Say the word if you'd rather have it continuous — it's one line.

This is the copy on `main`, which is the one that takes effect (Renovate reads config from the default branch even though every PR it opens targets `previews`). The byte-identical mirror on `previews` is [the companion PR](https://github.com/yschimke/compose-samples/pulls).

## Test plan

- `renovate.json` parses; `automerge` is a documented Renovate option and the group's `enabled: true` already overrides the disable-everything rule above it.
- No workflow changes needed — `design-artifacts.yml`'s existing `push` → `previews` path filter already lists `*/gradle/libs.versions.toml`.
- First real check: next Monday's window should produce a `compose-ai-tools` PR against `previews` that merges itself once green, followed by a `Design Artifacts` run triggered by `push`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PVsxtNYPLpmz4KDhAojLyi)_