### PR TITLE
ci: automerge the compose-ai-tools bump on previews (previews mirror)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,12 +10,14 @@
       "enabled": false
     },
     {
+      "description": "compose-ai-tools ships the ee.schimke.composeai.preview Gradle plugin and the preview-annotations artifact as one release, and that release IS the renderer behind the published catalogs — the samples' own UI code is upstream Google's and barely moves, so a stale pin here is the main way /jetnews, /jetcaster & co. go stale. Automerge once CI on `previews` is green: design-artifacts.yml already re-renders and republishes every delivery branch on push to `previews` whenever */gradle/libs.versions.toml moves, and a Renovate merge is made with the app's token, which does raise `push` — so the bump lands and the catalogs regenerate with nobody in the loop. platformAutomerge stays false via the shared preset, so Renovate waits for every check instead of merging ahead of them. Deliberately left on the preset's weekly schedule rather than `at any time` (which cadence / meshcore-mobile / homeassistant-remotecompose use): a republish here is seven systems x re-theme + publish, and compose-ai-tools releases several times a day.",
       "groupName": "compose-ai-tools",
       "matchDepNames": [
         "ee.schimke.composeai.preview",
         "ee.schimke.composeai:preview-annotations"
       ],
-      "enabled": true
+      "enabled": true,
+      "automerge": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

Mirrors #12 onto `previews`, keeping the two `renovate.json` copies byte-identical.

Renovate reads its config from the **default** branch, so `main`'s copy (#12) is the one that actually takes effect; this copy exists so the branch that carries the catalogs also carries the config that updates them, and so the two can't quietly disagree about what happens on `previews`.

Merge #12 too — this one alone changes nothing.

## Test plan

- `renovate.json` parses.
- Diff against #12's version is empty.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PVsxtNYPLpmz4KDhAojLyi)_