### PR TITLE
ci(design-artifacts): always render previews, whatever triggered the run

### DIFF
--- a/.github/workflows/design-artifacts.yml
+++ b/.github/workflows/design-artifacts.yml
@@ -68,6 +68,12 @@ jobs:
       - name: Check out compose-samples
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          # The catalogs, their specs and m3-theme-overrides.mjs all live on
+          # `previews`; none of them exist on `main`. A push run would check the
+          # right commit out anyway, but a `workflow_dispatch` (and any future
+          # `schedule`) can only ever run the copy of this file on the DEFAULT
+          # branch and would otherwise check out `main` and find nothing.
+          ref: previews
           persist-credentials: false
 
       - name: Set up JDK 21
@@ -213,6 +219,12 @@ jobs:
       spec: ${{ matrix.spec }}
       module: ${{ matrix.module }}
       working-directory: ${{ matrix.dir }}
+      # Render `previews`, the branch the catalogs live on — not whatever ref
+      # triggered this. Only matters for triggers that can't imply the ref: a
+      # `workflow_dispatch` is offered solely for the default branch's copy of
+      # this file and would otherwise render a `main` that carries no
+      # catalog.spec.json at all. See the note on the retheme checkout above.
+      ref: previews
       preview-annotations: ${{ matrix.preview-annotations || '' }}
       # Carry the executable render bundle onto the delivery branch and split it
       # per preview, so preview.coo.ee re-renders these live instead of replaying


### PR DESCRIPTION
## Summary

Same class of bug as yschimke/horologist#11, and a bit worse here.

The catalogs, their specs and `m3-theme-overrides.mjs` all live on `previews` — **`main` has zero catalog spec files**. Both checkouts in this workflow took the triggering ref, which is right for a push to `previews` and wrong for anything else.

GitHub offers `workflow_dispatch` (and raises `schedule`) only for the copy of a workflow on the **default** branch, and such a run checks that branch out. So dispatching Design Artifacts by hand has been checking out `main` and looking for `JetNews/catalog.spec.json` in a branch that has no spec files at all.

This names the branch explicitly in both places:

- the reusable publish workflow's `ref` input;
- the `retheme_m3` job's `actions/checkout` of this repo, which also needs `previews` for `.github/scripts/m3-theme-overrides.mjs` and the sample theme sources it reads.

Push-triggered runs are unaffected in behaviour — they already checked out the right commit.

## Companion PR

The `main` copy is an *older* version of this workflow (no path filter, no `retheme_m3`, no `jetcaster-wear`), and it's the copy every dispatch actually uses. The companion PR replaces it with this one so the two stay byte-identical. **Both should land** — either alone leaves the pair inconsistent, which is the condition that hid this in the first place.

## Scope note

compose-samples has **no `schedule`** at all, so "automatic runs" here means push-to-`previews` only, and those already worked. If you want the weekly drift-catching cron the sibling repos have — the renderer moves under the delivery branches even when this repo doesn't change — say so and I'll add it, but it's 7 systems × (re-theme + publish) per week, so I didn't add it unasked.

## Test plan

- `design-artifacts.yml` parses as YAML.
- `ref` is a real input on `design-artifacts-reusable.yml` (compose-ai-tools 0.19.10, #3022), documented for this exact scenario.
- Confirmed `main` carries 0 files matching `catalog*.spec.json` and no `m3-theme-overrides.mjs`, while `previews` carries 7 and 1 — so the pre-change dispatch had nothing to render.
- Real check: dispatch Design Artifacts from the Actions tab after both PRs land. It should render the seven systems instead of failing to find a spec.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PVsxtNYPLpmz4KDhAojLyi)_