### PR TITLE
chore(previews): update compose preview to 0.19.19

### DIFF
--- a/JetLagged/gradle/libs.versions.toml
+++ b/JetLagged/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-composeAiPreview = "0.19.15"
+composeAiPreview = "0.19.19"
 accompanist = "0.37.3"
 android-material3 = "1.14.0"
 androidGradlePlugin = "9.2.1"

--- a/JetNews/gradle/libs.versions.toml
+++ b/JetNews/gradle/libs.versions.toml
@@ -4,7 +4,7 @@
 #####
 [versions]
 accompanist = "0.37.3"
-composeAiPreview = "0.19.15"
+composeAiPreview = "0.19.19"
 android-material3 = "1.14.0"
 androidGradlePlugin = "9.2.1"
 androidx-activity-compose = "1.13.0"

--- a/Jetcaster/gradle/libs.versions.toml
+++ b/Jetcaster/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 # Do not add a dependency to an individual sample, edit the global version instead.
 #####
 [versions]
-composeAiPreview = "0.19.15"
+composeAiPreview = "0.19.19"
 accompanist = "0.37.3"
 android-material3 = "1.14.0"
 androidGradlePlugin = "9.2.1"

--- a/Jetchat/gradle/libs.versions.toml
+++ b/Jetchat/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 # Do not add a dependency to an individual sample, edit the global version instead.
 #####
 [versions]
-composeAiPreview = "0.19.15"
+composeAiPreview = "0.19.19"
 accompanist = "0.37.3"
 android-material3 = "1.14.0"
 androidGradlePlugin = "9.2.1"

--- a/Jetsnack/gradle/libs.versions.toml
+++ b/Jetsnack/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-composeAiPreview = "0.19.15"
+composeAiPreview = "0.19.19"
 accompanist = "0.37.3"
 android-material3 = "1.14.0"
 androidGradlePlugin = "9.2.1"

--- a/Reply/gradle/libs.versions.toml
+++ b/Reply/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 # Do not add a dependency to an individual sample, edit the global version instead.
 #####
 [versions]
-composeAiPreview = "0.19.15"
+composeAiPreview = "0.19.19"
 accompanist = "0.37.3"
 android-material3 = "1.14.0"
 androidGradlePlugin = "9.2.1"


### PR DESCRIPTION
Bumps `composeAiPreview` from 0.19.15 to 0.19.19 across all six samples (JetLagged, JetNews, Jetcaster, Jetchat, Jetsnack, Reply).

The delivery branches have been rendering with 0.19.15 while four releases landed, so this picks up 0.19.16–0.19.19. The headline one for these catalogs is compose-ai-tools#3180 (`fix(figma-svg): clip a lookahead scroll container to its rendered viewport`), the fix for the Jetsnack **Catalog/Filter screen** SVG in compose-ai-tools#3056 — its published SVG has been byte-identical since the 0.19.12 export, exporting the lookahead content box (1082×2132) instead of the rendered viewport, so the divider, Category header, slider and Lifestyle controls render below the white sheet.

Because a `*/gradle/libs.versions.toml` change is a `design-artifacts.yml` trigger path, merging this re-renders and republishes every `design-artifacts/<system>` branch with the new renderer.

## Test plan

Verification is the CI render itself — this is a version-only change, so the evidence is what the pipeline publishes:

- [ ] `design-artifacts` succeeds for all seven systems (six samples + jetcaster-wear).
- [ ] `figma/catalog-filter-screen/ideal__default.svg` on `design-artifacts/jetsnack` stops being byte-identical to the 0.19.12 export, and its `height` drops from the 2132 content box to the rendered viewport.
- [ ] Jetsnack's Filter screen no longer shows the divider / Category header / slider / Lifestyle controls stranded below the white sheet.

### Known gap, tracked separately

0.19.19 carries compose-ai-tools#3180 but **not** its follow-up compose-ai-tools#3181 (`keep a clipped node's fill at its painted width`), which merged ~30 minutes after the 0.19.19 release PR was cut and is queued in the open `chore(main): release 0.19.20` PR. Checked against the `v0.19.19` tag directly: #3180's Jetsnack-chain fixture test passes there, but #3181's `aFixedClipAroundARequiredSizeOverflowDoesNotWidenTheFill` case fails — a clipped node's fill is emitted at the clip box rather than its painted extent. Jetsnack's Filter screen has the trailing `padding(horizontal = 24.dp)` that makes the viewport wider than the content, so its sheet fill may paint across the side margins until 0.19.20 lands. That's a follow-up bump, not a reason to hold this one — the truncation fix is the larger correction and it ships here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YDVV1mUQPqzyfLCZmNLgRt)_