### PR TITLE
chore(previews): update compose preview to 0.19.20

### DIFF
--- a/JetLagged/gradle/libs.versions.toml
+++ b/JetLagged/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-composeAiPreview = "0.19.19"
+composeAiPreview = "0.19.20"
 accompanist = "0.37.3"
 android-material3 = "1.14.0"
 androidGradlePlugin = "9.2.1"

--- a/JetNews/gradle/libs.versions.toml
+++ b/JetNews/gradle/libs.versions.toml
@@ -4,7 +4,7 @@
 #####
 [versions]
 accompanist = "0.37.3"
-composeAiPreview = "0.19.19"
+composeAiPreview = "0.19.20"
 android-material3 = "1.14.0"
 androidGradlePlugin = "9.2.1"
 androidx-activity-compose = "1.13.0"

--- a/Jetcaster/gradle/libs.versions.toml
+++ b/Jetcaster/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 # Do not add a dependency to an individual sample, edit the global version instead.
 #####
 [versions]
-composeAiPreview = "0.19.19"
+composeAiPreview = "0.19.20"
 accompanist = "0.37.3"
 android-material3 = "1.14.0"
 androidGradlePlugin = "9.2.1"

--- a/Jetchat/gradle/libs.versions.toml
+++ b/Jetchat/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 # Do not add a dependency to an individual sample, edit the global version instead.
 #####
 [versions]
-composeAiPreview = "0.19.19"
+composeAiPreview = "0.19.20"
 accompanist = "0.37.3"
 android-material3 = "1.14.0"
 androidGradlePlugin = "9.2.1"

--- a/Jetsnack/gradle/libs.versions.toml
+++ b/Jetsnack/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-composeAiPreview = "0.19.19"
+composeAiPreview = "0.19.20"
 accompanist = "0.37.3"
 android-material3 = "1.14.0"
 androidGradlePlugin = "9.2.1"

--- a/Reply/gradle/libs.versions.toml
+++ b/Reply/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 # Do not add a dependency to an individual sample, edit the global version instead.
 #####
 [versions]
-composeAiPreview = "0.19.19"
+composeAiPreview = "0.19.20"
 accompanist = "0.37.3"
 android-material3 = "1.14.0"
 androidGradlePlugin = "9.2.1"


### PR DESCRIPTION
Bumps `composeAiPreview` 0.19.19 → 0.19.20 across all six samples (JetLagged, JetNews, Jetcaster, Jetchat, Jetsnack, Reply).

## Why

Follow-up to #16. That bump carried the scroll-container viewport clip ([compose-ai-tools#3180](https://github.com/yschimke/compose-ai-tools/pull/3180), issue #3056), which corrected `clip-0` on the Jetsnack filter screen but also shrank the sheet's *fill* to the clip viewport. 0.19.20 contains the follow-up fix — [`fix(figma-svg): keep a clipped node's fill at its painted width`](https://github.com/yschimke/compose-ai-tools/pull/3181) — so a clipped node's fill keeps its painted extent while the clip rect stays corrected.

Also picks up the rest of the 0.19.20 renderer/serve changes ([release notes](https://github.com/yschimke/compose-ai-tools/releases/tag/v0.19.20)).

## Visual evidence

Version-only change to the toolchain pin — no sample source or `@Preview` is edited here, so there is no before/after to embed from this diff. The visual effect lands in the *rendered* catalogs, which this branch does not contain: the `design-artifacts.yml` render on merge regenerates `design-artifacts/<system>`, and the CI visual-diff bot comments the re-rendered previews on this PR. The specific regression this unblocks is verified on `design-artifacts/jetsnack` after merge:

- `figma/catalog-filter-screen/ideal__default.svg` — sheet fill back at `x=105 width=840` (its painted extent)
- same file — `clip-0` unchanged at `x=42 y=460 966x1181` (the corrected viewport from #16)

I'll confirm both once the post-merge render lands.

## Test plan

- CI render on this PR (visual-diff bot comment)
- Post-merge: assert the two geometry facts above on `design-artifacts/jetsnack`

---
_Generated by [Claude Code](https://claude.ai/code/session_01YDVV1mUQPqzyfLCZmNLgRt)_