### PR TITLE
chore(previews): update compose preview to 0.19.25

### DIFF
--- a/JetLagged/gradle/libs.versions.toml
+++ b/JetLagged/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-composeAiPreview = "0.19.20"
+composeAiPreview = "0.19.25"
 accompanist = "0.37.3"
 android-material3 = "1.14.0"
 androidGradlePlugin = "9.2.1"

--- a/JetNews/gradle/libs.versions.toml
+++ b/JetNews/gradle/libs.versions.toml
@@ -4,7 +4,7 @@
 #####
 [versions]
 accompanist = "0.37.3"
-composeAiPreview = "0.19.20"
+composeAiPreview = "0.19.25"
 android-material3 = "1.14.0"
 androidGradlePlugin = "9.2.1"
 androidx-activity-compose = "1.13.0"

--- a/Jetcaster/gradle/libs.versions.toml
+++ b/Jetcaster/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 # Do not add a dependency to an individual sample, edit the global version instead.
 #####
 [versions]
-composeAiPreview = "0.19.20"
+composeAiPreview = "0.19.25"
 accompanist = "0.37.3"
 android-material3 = "1.14.0"
 androidGradlePlugin = "9.2.1"

--- a/Jetchat/gradle/libs.versions.toml
+++ b/Jetchat/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 # Do not add a dependency to an individual sample, edit the global version instead.
 #####
 [versions]
-composeAiPreview = "0.19.20"
+composeAiPreview = "0.19.25"
 accompanist = "0.37.3"
 android-material3 = "1.14.0"
 androidGradlePlugin = "9.2.1"

--- a/Jetsnack/gradle/libs.versions.toml
+++ b/Jetsnack/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-composeAiPreview = "0.19.20"
+composeAiPreview = "0.19.25"
 accompanist = "0.37.3"
 android-material3 = "1.14.0"
 androidGradlePlugin = "9.2.1"

--- a/Reply/gradle/libs.versions.toml
+++ b/Reply/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 # Do not add a dependency to an individual sample, edit the global version instead.
 #####
 [versions]
-composeAiPreview = "0.19.20"
+composeAiPreview = "0.19.25"
 accompanist = "0.37.3"
 android-material3 = "1.14.0"
 androidGradlePlugin = "9.2.1"


### PR DESCRIPTION
Bumps `composeAiPreview` from `0.19.20` to `0.19.25` across all six sample catalogs: JetLagged, JetNews, Jetcaster, Jetchat, Jetsnack and Reply.

Version-catalog only — the workflow refs here are `@main` and float already.

0.19.21–0.19.25 are almost entirely `serve` (preview.coo.ee) changes: catalog pages painted in their own design tokens, two theme-render bursts instead of one, background theme optimisation parked while catalogs load, and snapshot renders routed back to the shared daemon. Since the samples' own UI is upstream Google's and barely moves, the renderer pin is the main thing that changes what `/jetnews/`, `/jetcaster/` & co. actually serve — this bump is expected to change the published output rather than being a no-op.

A design-artifacts run is already in flight against this branch, so the rendered result can be compared before merging.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BEAnP7catuBrUzog96WT1C)_