### PR TITLE
Fix catalog light and dark previews

### DIFF
--- a/JetLagged/app/src/debug/java/com/example/jetlagged/catalog/JetLaggedCatalogPreviews.kt
+++ b/JetLagged/app/src/debug/java/com/example/jetlagged/catalog/JetLaggedCatalogPreviews.kt
@@ -16,8 +16,12 @@
 
 package com.example.jetlagged.catalog
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.example.jetlagged.AverageTimeAsleepCard
 import com.example.jetlagged.AverageTimeInBedCard
 import com.example.jetlagged.WellnessCard
@@ -50,6 +54,7 @@ import com.example.jetlagged.ui.theme.JetLaggedTheme
 
 @Preview(name = "Average time asleep", showBackground = true, widthDp = 400)
 @Composable
+@PreviewLightDark
 fun AverageTimeAsleepCardCatalogPreview() {
     JetLaggedTheme { AverageTimeAsleepCard() }
 }
@@ -63,6 +68,7 @@ fun AverageTimeAsleepCardWideCatalogPreview() {
 
 @Preview(name = "Average time in bed", showBackground = true, widthDp = 400)
 @Composable
+@PreviewLightDark
 fun AverageTimeInBedCardCatalogPreview() {
     JetLaggedTheme { AverageTimeInBedCard() }
 }
@@ -76,18 +82,25 @@ fun AverageTimeInBedCardWideCatalogPreview() {
 
 @Preview(name = "Heart rate", showBackground = true, widthDp = 400)
 @Composable
+@PreviewLightDark
 fun HeartRateCardCatalogPreview() {
     JetLaggedTheme { HeartRateCard() }
 }
 
 @Preview(name = "Wellness", showBackground = true, widthDp = 400)
 @Composable
+@PreviewLightDark
 fun WellnessCardCatalogPreview() {
     JetLaggedTheme { WellnessCard() }
 }
 
 @Preview(name = "Header", showBackground = true, widthDp = 400)
 @Composable
+@PreviewLightDark
 fun JetLaggedHeaderCatalogPreview() {
-    JetLaggedTheme { JetLaggedHeader() }
+    JetLaggedTheme {
+        Box(Modifier.background(JetLaggedTheme.extraColors.header)) {
+            JetLaggedHeader()
+        }
+    }
 }

--- a/JetLagged/app/src/debug/java/com/example/jetlagged/catalog/JetLaggedComponentPreviews.kt
+++ b/JetLagged/app/src/debug/java/com/example/jetlagged/catalog/JetLaggedComponentPreviews.kt
@@ -18,6 +18,7 @@ package com.example.jetlagged.catalog
 
 import android.content.res.Configuration
 import androidx.compose.foundation.background
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -41,6 +42,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.example.jetlagged.BasicInformationalCard
 import com.example.jetlagged.HomeScreenCardHeading
@@ -83,7 +85,7 @@ import com.example.jetlagged.ui.theme.SmallHeadingStyle
  */
 
 @Composable
-private fun Wrap(dark: Boolean = false, content: @Composable () -> Unit) = JetLaggedTheme(isDarkTheme = dark) {
+private fun Wrap(dark: Boolean = isSystemInDarkTheme(), content: @Composable () -> Unit) = JetLaggedTheme(isDarkTheme = dark) {
     Surface(color = MaterialTheme.colorScheme.background) {
         Box(Modifier.padding(8.dp)) { content() }
     }
@@ -93,6 +95,7 @@ private fun Wrap(dark: Boolean = false, content: @Composable () -> Unit) = JetLa
 
 @Preview(name = "SleepBar", showBackground = true, widthDp = 380, heightDp = 80)
 @Composable
+@PreviewLightDark
 fun SleepBarCatalogPreview() = Wrap {
     SleepBar(sleepData = singleNight, modifier = Modifier.fillMaxWidth())
 }
@@ -153,6 +156,7 @@ private fun SleepStageSwatches() {
 
 @Preview(name = "Sleep stage palette", showBackground = true, widthDp = 380, heightDp = 100)
 @Composable
+@PreviewLightDark
 fun SleepStagePalettePreview() = Wrap { SleepStageSwatches() }
 
 @Preview(
@@ -169,6 +173,7 @@ fun SleepStagePaletteDarkPreview() = Wrap(dark = true) { SleepStageSwatches() }
 
 @Preview(name = "SleepGraphCard — week", showBackground = true, widthDp = 700, heightDp = 460)
 @Composable
+@PreviewLightDark
 fun JetLaggedSleepGraphCardPreview() = Wrap {
     JetLaggedSleepGraphCard(sleepState = weekOfSleep)
 }
@@ -197,6 +202,7 @@ fun JetLaggedSleepGraphCardDarkPreview() = Wrap(dark = true) {
  */
 @Preview(name = "TimeGraph — bare layout", showBackground = true, widthDp = 760, heightDp = 340)
 @Composable
+@PreviewLightDark
 fun TimeGraphPreview() = Wrap {
     val graph = weekOfSleep
     val hours = (graph.earliestStartHour..23) + (0..graph.latestEndHour)
@@ -243,6 +249,7 @@ fun TimeGraphPreview() = Wrap {
 
 @Preview(name = "HeartRateGraph", showBackground = true, widthDp = 420, heightDp = 120)
 @Composable
+@PreviewLightDark
 fun HeartRateGraphPreview() = Wrap {
     HeartRateGraph(listData = HeartRateOverallData().listData)
 }
@@ -279,6 +286,7 @@ fun HeartRateCardRestingPreview() = Wrap {
 
 @Preview(name = "BasicInformationalCard", showBackground = true, widthDp = 320, heightDp = 160)
 @Composable
+@PreviewLightDark
 fun BasicInformationalCardPreview() = Wrap {
     BasicInformationalCard(borderColor = MaterialTheme.colorScheme.primary) {
         Box(Modifier.padding(24.dp)) { HomeScreenCardHeading(text = "Sleep") }
@@ -287,6 +295,7 @@ fun BasicInformationalCardPreview() = Wrap {
 
 @Preview(name = "TwoLineInfoCard", showBackground = true, widthDp = 240, heightDp = 240)
 @Composable
+@PreviewLightDark
 fun TwoLineInfoCardPreview() = Wrap {
     TwoLineInfoCard(
         borderColor = JetLaggedTheme.extraColors.bed,
@@ -329,18 +338,21 @@ fun WellnessCardDarkPreview() = Wrap(dark = true) {
 
 @Preview(name = "WellnessBubble", showBackground = true, widthDp = 140, heightDp = 140)
 @Composable
+@PreviewLightDark
 fun WellnessBubblePreview() = Wrap {
     WellnessBubble(titleText = "Snoring", countText = "128", metric = "min")
 }
 
 @Preview(name = "CardHeading", showBackground = true, widthDp = 320, heightDp = 60)
 @Composable
+@PreviewLightDark
 fun HomeScreenCardHeadingPreview() = Wrap { HomeScreenCardHeading(text = "Wellness") }
 
 // ---------------------------------------------------------------- chrome
 
 @Preview(name = "HeaderTabs — Week", showBackground = true, widthDp = 400, heightDp = 72)
 @Composable
+@PreviewLightDark
 fun JetLaggedHeaderTabsPreview() = Wrap { HeaderTabs(SleepTab.Week) }
 
 @Preview(name = "HeaderTabs — Day", showBackground = true, widthDp = 400, heightDp = 72)

--- a/JetLagged/app/src/debug/java/com/example/jetlagged/catalog/JetLaggedScreenPreviews.kt
+++ b/JetLagged/app/src/debug/java/com/example/jetlagged/catalog/JetLaggedScreenPreviews.kt
@@ -17,10 +17,12 @@
 package com.example.jetlagged.catalog
 
 import android.content.res.Configuration
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.example.jetlagged.JetLaggedScreen
 import com.example.jetlagged.data.JetLaggedHomeScreenState
 import com.example.jetlagged.data.JetLaggedHomeScreenViewModel
@@ -56,7 +58,7 @@ import com.example.jetlagged.ui.theme.JetLaggedTheme
 private val fixtureState = JetLaggedHomeScreenState(sleepGraphData = weekOfSleep)
 
 @Composable
-private fun Screen(windowSizeClass: WindowWidthSizeClass, dark: Boolean = false) = JetLaggedTheme(isDarkTheme = dark) {
+private fun Screen(windowSizeClass: WindowWidthSizeClass, dark: Boolean = isSystemInDarkTheme()) = JetLaggedTheme(isDarkTheme = dark) {
     JetLaggedScreen(
         windowSizeClass = windowSizeClass,
         viewModel = remember { JetLaggedHomeScreenViewModel(fixtureState) },
@@ -65,6 +67,7 @@ private fun Screen(windowSizeClass: WindowWidthSizeClass, dark: Boolean = false)
 
 @Preview(name = "Home — compact", showBackground = true, widthDp = 412, heightDp = 1100)
 @Composable
+@PreviewLightDark
 fun JetLaggedScreenCompactPreview() = Screen(WindowWidthSizeClass.Compact)
 
 /** Above compact the cards reflow into `FlowColumn`s beside the graph rather than stacking. */

--- a/JetLagged/app/src/debug/java/com/example/jetlagged/catalog/JetLaggedThemeCatalogs.kt
+++ b/JetLagged/app/src/debug/java/com/example/jetlagged/catalog/JetLaggedThemeCatalogs.kt
@@ -42,13 +42,13 @@ import ee.schimke.composeai.preview.ThemeCatalog
  * These live in the `debug` source set, so nothing here reaches a release build.
  */
 
-@ThemeCatalog(name = "Light", group = "JetLagged")
+@ThemeCatalog(name = "JetLagged · Light", group = "JetLagged")
 class JetLaggedLightThemeCatalog : PreviewWrapperProvider {
     @Composable
     override fun Wrap(content: @Composable () -> Unit) = JetLaggedTheme(isDarkTheme = false, content = content)
 }
 
-@ThemeCatalog(name = "Dark", group = "JetLagged")
+@ThemeCatalog(name = "JetLagged · Dark", group = "JetLagged")
 class JetLaggedDarkThemeCatalog : PreviewWrapperProvider {
     @Composable
     override fun Wrap(content: @Composable () -> Unit) = JetLaggedTheme(isDarkTheme = true, content = content)

--- a/JetLagged/app/src/main/java/com/example/jetlagged/backgrounds/FadingCircleBackground.kt
+++ b/JetLagged/app/src/main/java/com/example/jetlagged/backgrounds/FadingCircleBackground.kt
@@ -23,6 +23,8 @@ import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
@@ -31,8 +33,10 @@ import androidx.compose.ui.draw.drawWithCache
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.example.jetlagged.ui.theme.JetLaggedTheme
 import kotlin.math.ceil
 
 @Composable
@@ -83,6 +87,14 @@ fun FadingCircleBackground(bubbleSize: Dp, color: Color) {
 
 @Preview
 @Composable
+@PreviewLightDark
 fun FadingCirclePreview() {
-    FadingCircleBackground(bubbleSize = 30.dp, color = Color.Red)
+    JetLaggedTheme {
+        Surface(color = MaterialTheme.colorScheme.background) {
+            FadingCircleBackground(
+                bubbleSize = 30.dp,
+                color = JetLaggedTheme.extraColors.sleepChartPrimary,
+            )
+        }
+    }
 }

--- a/JetLagged/app/src/main/java/com/example/jetlagged/sleep/SleepBar.kt
+++ b/JetLagged/app/src/main/java/com/example/jetlagged/sleep/SleepBar.kt
@@ -41,6 +41,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -73,6 +74,7 @@ import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.drawText
 import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.lerp
 import com.example.jetlagged.data.sleepData
@@ -109,7 +111,7 @@ fun SleepBar(sleepData: SleepDayData, modifier: Modifier = Modifier) {
                 animationSpec = tween(animationDuration),
             ),
             content = {
-                DetailLegend()
+                DetailLegendContent()
             },
             visible = { it },
         )
@@ -292,7 +294,15 @@ private fun generateSleepPath(
 
 @Preview
 @Composable
+@PreviewLightDark
 private fun DetailLegend() {
+    JetLaggedTheme {
+        Surface { DetailLegendContent() }
+    }
+}
+
+@Composable
+private fun DetailLegendContent() {
     Row(
         modifier = Modifier.padding(top = 8.dp),
         horizontalArrangement = Arrangement.spacedBy(8.dp),

--- a/JetNews/app/src/debug/java/com/example/jetnews/catalog/JetnewsAnimationPreviews.kt
+++ b/JetNews/app/src/debug/java/com/example/jetnews/catalog/JetnewsAnimationPreviews.kt
@@ -33,6 +33,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.example.jetnews.data.posts.impl.post3
 import com.example.jetnews.ui.home.PostCardHistory
@@ -78,6 +79,7 @@ import kotlinx.coroutines.delay
     uiMode = Configuration.UI_MODE_NIGHT_YES,
 )
 @Composable
+@PreviewLightDark
 fun PopularPostCardCatalogPreview() {
     JetnewsTheme {
         Surface {

--- a/JetNews/app/src/debug/java/com/example/jetnews/catalog/JetnewsScreenPreviews.kt
+++ b/JetNews/app/src/debug/java/com/example/jetnews/catalog/JetnewsScreenPreviews.kt
@@ -30,6 +30,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.example.jetnews.R
 import com.example.jetnews.data.AppContainer
 import com.example.jetnews.data.Result
@@ -379,6 +380,7 @@ fun PreviewPublicationsTabFollowed() {
  */
 @Preview("App — compact (single pane)", widthDp = 412, heightDp = 900)
 @Composable
+@PreviewLightDark
 fun PreviewJetnewsAppCompact() {
     JetnewsApp(
         appContainer = remember { PreviewAppContainer() },

--- a/JetNews/app/src/debug/java/com/example/jetnews/catalog/JetnewsThemeCatalogs.kt
+++ b/JetNews/app/src/debug/java/com/example/jetnews/catalog/JetnewsThemeCatalogs.kt
@@ -48,13 +48,13 @@ import ee.schimke.composeai.preview.ThemeCatalog
 private fun JetnewsScheme(scheme: ColorScheme, content: @Composable () -> Unit) =
     MaterialTheme(colorScheme = scheme, shapes = JetnewsShapes, typography = JetnewsTypography, content = content)
 
-@ThemeCatalog(name = "Light", group = "JetNews")
+@ThemeCatalog(name = "JetNews · Light", group = "JetNews")
 class JetnewsLightThemeCatalog : PreviewWrapperProvider {
     @Composable
     override fun Wrap(content: @Composable () -> Unit) = JetnewsScheme(LightColors, content)
 }
 
-@ThemeCatalog(name = "Dark", group = "JetNews")
+@ThemeCatalog(name = "JetNews · Dark", group = "JetNews")
 class JetnewsDarkThemeCatalog : PreviewWrapperProvider {
     @Composable
     override fun Wrap(content: @Composable () -> Unit) = JetnewsScheme(DarkColors, content)

--- a/JetNews/app/src/main/java/com/example/jetnews/ui/AppDrawer.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/AppDrawer.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import androidx.navigation3.runtime.NavKey
 import com.example.jetnews.R
@@ -97,6 +98,7 @@ private fun JetNewsLogo(modifier: Modifier = Modifier) {
 @Preview("Drawer contents")
 @Preview("Drawer contents (dark)", uiMode = UI_MODE_NIGHT_YES)
 @Composable
+@PreviewLightDark
 fun PreviewAppDrawer() {
     JetnewsTheme {
         AppDrawer(

--- a/JetNews/app/src/main/java/com/example/jetnews/ui/components/AppNavRail.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/components/AppNavRail.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import androidx.navigation3.runtime.NavKey
 import com.example.jetnews.R
@@ -81,6 +82,7 @@ fun AppNavRail(
 @Preview("Drawer contents")
 @Preview("Drawer contents (dark)", uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
+@PreviewLightDark
 fun PreviewAppNavRail() {
     JetnewsTheme {
         AppNavRail(

--- a/JetNews/app/src/main/java/com/example/jetnews/ui/home/HomeScreens.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/home/HomeScreens.kt
@@ -83,6 +83,7 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -673,6 +674,7 @@ private fun HomeTopAppBar(
     heightDp = 900,
 )
 @Composable
+@PreviewLightDark
 fun PreviewHomeListDrawerScreen() {
     val postsFeed = runBlocking {
         (BlockingFakePostsRepository().getPostsFeed() as Result.Success).data

--- a/JetNews/app/src/main/java/com/example/jetnews/ui/home/PostCardTop.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/home/PostCardTop.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.example.jetnews.R
 import com.example.jetnews.data.posts.impl.posts
@@ -90,6 +91,7 @@ fun PostCardTop(post: Post, modifier: Modifier = Modifier) {
  */
 @Preview
 @Composable
+@PreviewLightDark
 fun PostCardTopPreview() {
     JetnewsTheme {
         Surface {

--- a/JetNews/app/src/main/java/com/example/jetnews/ui/home/PostCards.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/home/PostCards.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.semantics.customActions
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.example.jetnews.R
 import com.example.jetnews.data.posts.impl.post3
@@ -193,6 +194,7 @@ fun PostCardHistory(post: Post, navigateToPost: (String) -> Unit, initialDialogO
 
 @Preview("Bookmark Button")
 @Composable
+@PreviewLightDark
 fun BookmarkButtonPreview() {
     JetnewsTheme {
         Surface {
@@ -214,6 +216,7 @@ fun BookmarkButtonBookmarkedPreview() {
 @Preview("Simple post card")
 @Preview("Simple post card (dark)", uiMode = UI_MODE_NIGHT_YES)
 @Composable
+@PreviewLightDark
 fun SimplePostPreview() {
     JetnewsTheme {
         Surface {
@@ -224,6 +227,7 @@ fun SimplePostPreview() {
 
 @Preview("Post History card")
 @Composable
+@PreviewLightDark
 fun HistoryPostPreview() {
     JetnewsTheme {
         Surface {

--- a/JetNews/app/src/main/java/com/example/jetnews/ui/interests/InterestsScreen.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/interests/InterestsScreen.kt
@@ -65,6 +65,7 @@ import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.constrainHeight
 import androidx.compose.ui.unit.constrainWidth
@@ -557,6 +558,7 @@ private fun InterestsAdaptiveContentLayout(
     fontScale = 1.5f, widthDp = 412, heightDp = 900,
 )
 @Composable
+@PreviewLightDark
 fun PreviewInterestsScreenDrawer() {
     JetnewsTheme {
         val tabContent = getFakeTabsContent()
@@ -606,6 +608,7 @@ fun PreviewInterestsScreenNavRail() {
 @Preview("Interests screen topics tab", "Topics")
 @Preview("Interests screen topics tab (dark)", "Topics", uiMode = UI_MODE_NIGHT_YES)
 @Composable
+@PreviewLightDark
 fun PreviewTopicsTab() {
     val topics = runBlocking {
         (FakeInterestsRepository().getTopics() as Result.Success).data
@@ -620,6 +623,7 @@ fun PreviewTopicsTab() {
 @Preview("Interests screen people tab", "People")
 @Preview("Interests screen people tab (dark)", "People", uiMode = UI_MODE_NIGHT_YES)
 @Composable
+@PreviewLightDark
 fun PreviewPeopleTab() {
     val people = runBlocking {
         (FakeInterestsRepository().getPeople() as Result.Success).data

--- a/JetNews/app/src/main/java/com/example/jetnews/ui/interests/SelectTopicButton.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/interests/SelectTopicButton.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.example.jetnews.R
 import com.example.jetnews.ui.theme.JetnewsTheme
@@ -69,6 +70,7 @@ fun SelectTopicButton(modifier: Modifier = Modifier, selected: Boolean = false) 
 @Preview("Off")
 @Preview("Off (dark)", uiMode = UI_MODE_NIGHT_YES)
 @Composable
+@PreviewLightDark
 fun SelectTopicButtonPreviewOff() {
     SelectTopicButtonPreviewTemplate(
         selected = false,

--- a/JetNews/app/src/main/java/com/example/jetnews/ui/post/PostContent.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/post/PostContent.kt
@@ -63,6 +63,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextIndent
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -332,6 +333,7 @@ private val ColorScheme.codeBlockBackground: Color
 @Preview("Post content")
 @Preview("Post content (dark)", uiMode = UI_MODE_NIGHT_YES)
 @Composable
+@PreviewLightDark
 fun PreviewPost() {
     JetnewsTheme {
         Surface {

--- a/JetNews/app/src/main/java/com/example/jetnews/ui/post/PostScreen.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/post/PostScreen.kt
@@ -67,6 +67,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
@@ -405,6 +406,7 @@ fun sharePost(post: Post, context: Context) {
 @Preview("Post screen (dark)", uiMode = UI_MODE_NIGHT_YES)
 @Preview("Post screen (big font)", fontScale = 1.5f, widthDp = 412, heightDp = 900)
 @Composable
+@PreviewLightDark
 fun PreviewPostDrawer() {
     JetnewsTheme {
         val post = runBlocking {

--- a/Jetcaster/mobile/src/debug/java/com/example/jetcaster/catalog/JetcasterComponentPreviews.kt
+++ b/Jetcaster/mobile/src/debug/java/com/example/jetcaster/catalog/JetcasterComponentPreviews.kt
@@ -16,6 +16,7 @@
 
 package com.example.jetcaster.catalog
 
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -34,6 +35,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.example.jetcaster.R
 import com.example.jetcaster.core.domain.testing.PreviewCategories
@@ -143,12 +145,10 @@ private val library = LibraryInfo(
         PodcastToEpisodeInfo(podcast = unsubscribedPodcast, episode = longTitleEpisode),
 )
 
-// The mode is pinned explicitly rather than left to isSystemInDarkTheme(), so a render is never at
-// the mercy of the harness's default uiMode. Dark is the default because dark is what Jetcaster is
-// designed around; the light variants below exist to exercise the other half of the design system,
-// which JetcasterTheme only started resolving once it stopped hardcoding darkScheme.
+// Follow the preview configuration by default so light/dark multipreviews and live uiMode
+// overrides reach the app theme. Individual palette specimens can still pass an explicit mode.
 @Composable
-private fun Wrap(dark: Boolean = true, content: @Composable () -> Unit) = JetcasterTheme(darkTheme = dark) {
+private fun Wrap(dark: Boolean = isSystemInDarkTheme(), content: @Composable () -> Unit) = JetcasterTheme(darkTheme = dark) {
     Surface { Box(Modifier.padding(8.dp)) { content() } }
 }
 
@@ -156,6 +156,7 @@ private fun Wrap(dark: Boolean = true, content: @Composable () -> Unit) = Jetcas
 
 @Preview(name = "FollowToggle — not following", showBackground = true)
 @Composable
+@PreviewLightDark
 fun JetcasterFollowToggleUnfollowedPreview() = Wrap {
     ToggleFollowPodcastIconButton(isFollowed = false, onClick = {})
 }
@@ -168,6 +169,7 @@ fun JetcasterFollowToggleFollowedPreview() = Wrap {
 
 @Preview(name = "SubscribeButtons — not subscribed", showBackground = true, widthDp = 412)
 @Composable
+@PreviewLightDark
 fun JetcasterSubscribeButtonsPreview() = Wrap {
     PodcastDetailsHeaderItemButtons(isSubscribed = false, onClick = {}, modifier = Modifier.fillMaxWidth())
 }
@@ -182,6 +184,7 @@ fun JetcasterSubscribeButtonsSubscribedPreview() = Wrap {
 
 @Preview(name = "TopPodcastRowItem — not following", showBackground = true, widthDp = 160)
 @Composable
+@PreviewLightDark
 fun JetcasterTopPodcastRowItemPreview() = Wrap {
     TopPodcastRowItem(
         podcastTitle = unsubscribedPodcast.title,
@@ -218,6 +221,7 @@ fun JetcasterTopPodcastRowItemLongTitlePreview() = Wrap {
 
 @Preview(name = "CategoryPodcastRow", showBackground = true, widthDp = 412, heightDp = 200)
 @Composable
+@PreviewLightDark
 fun JetcasterCategoryPodcastRowPreview() = Wrap {
     CategoryPodcastRow(
         podcasts = listOf(subscribedPodcast, unsubscribedPodcast, longTitlePodcast),
@@ -229,6 +233,7 @@ fun JetcasterCategoryPodcastRowPreview() = Wrap {
 
 @Preview(name = "CategoryChip — unselected", showBackground = true)
 @Composable
+@PreviewLightDark
 fun JetcasterCategoryChipPreview() = Wrap {
     ChoiceChipContent(text = "Comedy", selected = false, onClick = {})
 }
@@ -241,6 +246,7 @@ fun JetcasterCategoryChipSelectedPreview() = Wrap {
 
 @Preview(name = "CategoryTabs", showBackground = true, widthDp = 412)
 @Composable
+@PreviewLightDark
 fun JetcasterCategoryTabsPreview() = Wrap {
     PodcastCategoryTabs(
         filterableCategoriesModel = FilterableCategoriesModel(
@@ -339,6 +345,7 @@ fun JetcasterPodcastDetailsHeaderLongTitlePreview() = Wrap {
 
 @Preview(name = "PodcastDetails description — short", showBackground = true, widthDp = 412)
 @Composable
+@PreviewLightDark
 fun JetcasterPodcastDescriptionPreview() = Wrap {
     PodcastDetailsDescription(podcast = unsubscribedPodcast, modifier = Modifier.fillMaxWidth())
 }
@@ -351,6 +358,7 @@ fun JetcasterPodcastDescriptionOverflowPreview() = Wrap {
 
 @Preview(name = "PodcastDetails app bar", showBackground = true, widthDp = 412)
 @Composable
+@PreviewLightDark
 fun JetcasterPodcastDetailsTopAppBarPreview() = Wrap {
     PodcastDetailsTopAppBar(navigateBack = {}, modifier = Modifier.fillMaxWidth())
 }
@@ -370,6 +378,7 @@ fun JetcasterPodcastDetailsContentPreview() = Wrap {
 
 @Preview(name = "PodcastDetails screen — full screen", showBackground = true, widthDp = 412, heightDp = 900)
 @Composable
+@PreviewLightDark
 fun JetcasterPodcastDetailsFullScreenPreview() = Wrap {
     PodcastDetailsScreen(
         podcast = subscribedPodcast,
@@ -432,6 +441,7 @@ fun JetcasterPodcastDetailsExpandedLightPreview() = PodcastDetailsScreenPreview(
 
 @Preview(name = "Player screen — catalog", showBackground = true, widthDp = 412, heightDp = 900)
 @Composable
+@PreviewLightDark
 fun JetcasterPlayerScreenCatalogPreview() = PlayerScreenPreview()
 
 @Preview(name = "Player screen — medium", showBackground = true, widthDp = 700, heightDp = 840)
@@ -489,6 +499,7 @@ fun JetcasterPlayerButtonsNoQueuePreview() = Wrap {
 
 @Preview(name = "PlayerSlider — start", showBackground = true, widthDp = 412)
 @Composable
+@PreviewLightDark
 fun JetcasterPlayerSliderPreview() = Wrap {
     PlayerSlider(
         timeElapsed = Duration.ZERO,
@@ -522,12 +533,14 @@ fun JetcasterPlayerSliderCompletePreview() = Wrap {
 
 @Preview(name = "Player app bar", showBackground = true, widthDp = 412)
 @Composable
+@PreviewLightDark
 fun JetcasterPlayerTopAppBarPreview() = Wrap {
     TopAppBar(onBackPress = {}, onAddToQueue = {})
 }
 
 @Preview(name = "PodcastInformation", showBackground = true, widthDp = 412, heightDp = 420)
 @Composable
+@PreviewLightDark
 fun JetcasterPodcastInformationPreview() = Wrap {
     PodcastInformation(
         title = episode.title,
@@ -553,6 +566,7 @@ fun JetcasterHomeAppBarExpandedPreview() = Wrap {
 
 @Preview(name = "PillToolbar — Discover selected", showBackground = true, widthDp = 412)
 @Composable
+@PreviewLightDark
 fun JetcasterPillToolbarDiscoverPreview() = Wrap {
     PillToolbar(selectedHomeCategory = HomeCategory.Discover, onHomeAction = {})
 }
@@ -565,6 +579,7 @@ fun JetcasterPillToolbarLibraryPreview() = Wrap {
 
 @Preview(name = "Loading", showBackground = true, widthDp = 412, heightDp = 300)
 @Composable
+@PreviewLightDark
 fun JetcasterLoadingPreview() = Wrap { Loading(modifier = Modifier.fillMaxWidth()) }
 
 @Preview(name = "Home — error", showBackground = true, widthDp = 412, heightDp = 400)
@@ -589,6 +604,7 @@ fun JetcasterOfflineDialogPreview() = Wrap { OfflineDialog(onRetry = {}) }
 // above stays as the visual reference for the real windowed dialog.
 @Preview(name = "Offline state", showBackground = true, widthDp = 412, heightDp = 400)
 @Composable
+@PreviewLightDark
 fun JetcasterOfflineStatePreview() = Wrap {
     Box(Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
         Surface(
@@ -716,7 +732,8 @@ fun JetcasterHomeLibraryLightPreview() = JetcasterTheme(darkTheme = false) {
 // LocalSharedTransitionScope / LocalAnimatedVisibilityScope and throws without them.
 @Preview(name = "Home — discover", showBackground = true, widthDp = 412, heightDp = 640)
 @Composable
-fun JetcasterHomeDiscoverPreview() = JetcasterTheme(darkTheme = true) {
+@PreviewLightDark
+fun JetcasterHomeDiscoverPreview() = JetcasterTheme {
     SharedTransitionPreview {
         HomeScreen(
             isHomeAppBarExpanded = true,
@@ -742,7 +759,7 @@ fun JetcasterHomeDiscoverPreview() = JetcasterTheme(darkTheme = true) {
 
 @Preview(name = "Home — library", showBackground = true, widthDp = 412, heightDp = 900)
 @Composable
-fun JetcasterHomeLibraryPreview() = JetcasterTheme(darkTheme = true) {
+fun JetcasterHomeLibraryPreview() = JetcasterTheme {
     HomeScreen(
         isHomeAppBarExpanded = true,
         isLoading = false,
@@ -766,7 +783,7 @@ fun JetcasterHomeLibraryPreview() = JetcasterTheme(darkTheme = true) {
 
 @Preview(name = "Home — library, refreshing", showBackground = true, widthDp = 412, heightDp = 900)
 @Composable
-fun JetcasterHomeLoadingPreview() = JetcasterTheme(darkTheme = true) {
+fun JetcasterHomeLoadingPreview() = JetcasterTheme {
     HomeScreen(
         isHomeAppBarExpanded = true,
         isLoading = true,
@@ -787,7 +804,7 @@ fun JetcasterHomeLoadingPreview() = JetcasterTheme(darkTheme = true) {
 
 @Preview(name = "Home — empty library", showBackground = true, widthDp = 412, heightDp = 900)
 @Composable
-fun JetcasterHomeEmptyLibraryPreview() = JetcasterTheme(darkTheme = true) {
+fun JetcasterHomeEmptyLibraryPreview() = JetcasterTheme {
     HomeScreen(
         isHomeAppBarExpanded = true,
         isLoading = false,

--- a/Jetcaster/mobile/src/debug/java/com/example/jetcaster/catalog/JetcasterThemeCatalogs.kt
+++ b/Jetcaster/mobile/src/debug/java/com/example/jetcaster/catalog/JetcasterThemeCatalogs.kt
@@ -63,13 +63,13 @@ private fun JetcasterScheme(scheme: ColorScheme, content: @Composable () -> Unit
 )
 
 /** The scheme the app actually ships with — every other catalog here is currently unreachable. */
-@ThemeCatalog(name = "Dark", group = "Jetcaster")
+@ThemeCatalog(name = "Jetcaster · Dark", group = "Jetcaster")
 class JetcasterDarkThemeCatalog : PreviewWrapperProvider {
     @Composable
     override fun Wrap(content: @Composable () -> Unit) = JetcasterScheme(darkScheme, content)
 }
 
-@ThemeCatalog(name = "Light", group = "Jetcaster")
+@ThemeCatalog(name = "Jetcaster · Light", group = "Jetcaster")
 class JetcasterLightThemeCatalog : PreviewWrapperProvider {
     @Composable
     override fun Wrap(content: @Composable () -> Unit) = JetcasterScheme(lightScheme, content)

--- a/Jetcaster/mobile/src/main/java/com/example/jetcaster/ui/home/Home.kt
+++ b/Jetcaster/mobile/src/main/java/com/example/jetcaster/ui/home/Home.kt
@@ -88,6 +88,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -221,6 +222,7 @@ internal fun HomeScreenError(onRetry: () -> Unit, modifier: Modifier = Modifier)
 
 @Preview
 @Composable
+@PreviewLightDark
 fun HomeScreenErrorPreview() {
     JetcasterTheme {
         HomeScreenError(onRetry = {})
@@ -743,6 +745,7 @@ private fun lastUpdated(updated: OffsetDateTime): String {
 
 @Preview
 @Composable
+@PreviewLightDark
 private fun HomeAppBarPreview() {
     JetcasterTheme {
         HomeAppBar(
@@ -781,6 +784,7 @@ private fun PreviewHome() {
 
 @Composable
 @Preview
+@PreviewLightDark
 private fun PreviewPodcastCard() {
     JetcasterTheme {
         FollowedPodcastCarouselItem(

--- a/Jetcaster/mobile/src/main/java/com/example/jetcaster/ui/player/PlayerScreen.kt
+++ b/Jetcaster/mobile/src/main/java/com/example/jetcaster/ui/player/PlayerScreen.kt
@@ -62,6 +62,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Slider
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.ToggleButton
 import androidx.compose.material3.ToggleButtonColors
@@ -82,6 +83,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.window.core.layout.WindowSizeClass
@@ -879,17 +881,21 @@ private fun FullScreenLoading(modifier: Modifier = Modifier) {
 
 @Preview
 @Composable
+@PreviewLightDark
 fun TopAppBarPreview() {
     JetcasterTheme {
-        TopAppBar(
-            onBackPress = {},
-            onAddToQueue = {},
-        )
+        Surface {
+            TopAppBar(
+                onBackPress = {},
+                onAddToQueue = {},
+            )
+        }
     }
 }
 
 @Preview
 @Composable
+@PreviewLightDark
 fun PlayerButtonsPreview() {
     JetcasterTheme {
         PlayerButtons(

--- a/Jetcaster/mobile/src/main/java/com/example/jetcaster/ui/podcast/PodcastDetailsScreen.kt
+++ b/Jetcaster/mobile/src/main/java/com/example/jetcaster/ui/podcast/PodcastDetailsScreen.kt
@@ -44,6 +44,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.ToggleButton
 import androidx.compose.material3.ToggleButtonColors
@@ -65,6 +66,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.example.jetcaster.R
@@ -77,6 +79,7 @@ import com.example.jetcaster.designsystem.component.PodcastImage
 import com.example.jetcaster.designsystem.theme.Keyline1
 import com.example.jetcaster.ui.shared.EpisodeListItem
 import com.example.jetcaster.ui.shared.Loading
+import com.example.jetcaster.ui.theme.JetcasterTheme
 import com.example.jetcaster.ui.tooling.DevicePreviews
 import com.example.jetcaster.util.fullWidthItem
 import kotlinx.coroutines.launch
@@ -383,11 +386,16 @@ fun PodcastDetailsTopAppBar(navigateBack: () -> Unit, modifier: Modifier = Modif
 
 @Preview
 @Composable
+@PreviewLightDark
 fun PodcastDetailsHeaderItemPreview() {
-    PodcastDetailsHeaderItem(
-        podcast = PreviewPodcasts[0],
-        toggleSubscribe = { },
-    )
+    JetcasterTheme {
+        Surface {
+            PodcastDetailsHeaderItem(
+                podcast = PreviewPodcasts[0],
+                toggleSubscribe = { },
+            )
+        }
+    }
 }
 
 @DevicePreviews

--- a/Jetcaster/mobile/src/main/java/com/example/jetcaster/ui/shared/EpisodeListItem.kt
+++ b/Jetcaster/mobile/src/main/java/com/example/jetcaster/ui/shared/EpisodeListItem.kt
@@ -50,6 +50,7 @@ import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.example.jetcaster.R
 import com.example.jetcaster.core.domain.testing.PreviewEpisodes
@@ -297,6 +298,7 @@ private fun EpisodeListItemImage(podcast: PodcastInfo, modifier: Modifier = Modi
     uiMode = Configuration.UI_MODE_NIGHT_YES,
 )
 @Composable
+@PreviewLightDark
 private fun EpisodeListItemPreview() {
     JetcasterTheme {
         EpisodeListItem(

--- a/Jetchat/app/src/debug/java/com/example/compose/jetchat/catalog/JetchatComponentPreviews.kt
+++ b/Jetchat/app/src/debug/java/com/example/compose/jetchat/catalog/JetchatComponentPreviews.kt
@@ -19,6 +19,7 @@
 package com.example.compose.jetchat.catalog
 
 import android.content.res.Configuration
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -42,6 +43,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.example.compose.jetchat.FunctionalityNotAvailablePopup
 import com.example.compose.jetchat.R
@@ -118,7 +120,7 @@ private val richMessage = initialMessages[3]
 private val longMessage = initialMessages[4]
 
 @Composable
-private fun Wrap(dark: Boolean = false, content: @Composable () -> Unit) {
+private fun Wrap(dark: Boolean = isSystemInDarkTheme(), content: @Composable () -> Unit) {
     JetchatTheme(isDarkTheme = dark, isDynamicColor = false) {
         Surface { Box(Modifier.padding(8.dp)) { content() } }
     }
@@ -128,6 +130,7 @@ private fun Wrap(dark: Boolean = false, content: @Composable () -> Unit) {
 
 @Preview(name = "Message — other author", showBackground = true, widthDp = 400)
 @Composable
+@PreviewLightDark
 fun JetchatMessageOtherPreview() = Wrap {
     Message(
         onAuthorClick = {},
@@ -249,6 +252,7 @@ fun JetchatMessageMeDarkPreview() = Wrap(dark = true) {
 
 @Preview(name = "AuthorAndTextMessage — group head", showBackground = true, widthDp = 340)
 @Composable
+@PreviewLightDark
 fun JetchatAuthorAndTextMessagePreview() = Wrap {
     AuthorAndTextMessage(
         msg = otherMessage,
@@ -273,6 +277,7 @@ fun JetchatAuthorAndTextMessageContinuedPreview() = Wrap {
 
 @Preview(name = "ChatItemBubble — other author", showBackground = true, widthDp = 340)
 @Composable
+@PreviewLightDark
 fun JetchatChatItemBubbleOtherPreview() = Wrap {
     ChatItemBubble(message = otherMessage, isUserMe = false, authorClicked = {})
 }
@@ -291,6 +296,7 @@ fun JetchatChatItemBubbleWithImagePreview() = Wrap {
 
 @Preview(name = "ClickableMessage — mention and code", showBackground = true, widthDp = 340)
 @Composable
+@PreviewLightDark
 fun JetchatClickableMessagePreview() = Wrap {
     ClickableMessage(message = richMessage, isUserMe = false, authorClicked = {})
 }
@@ -305,6 +311,7 @@ fun JetchatClickableMessagePrimaryPreview() = Wrap {
 
 @Preview(name = "Messages", showBackground = true, widthDp = 400, heightDp = 640)
 @Composable
+@PreviewLightDark
 fun JetchatMessagesPreview() = Wrap {
     Messages(
         messages = initialMessages,
@@ -337,6 +344,7 @@ fun JetchatDayHeaderDarkPreview() = Wrap(dark = true) { DayHeader("Today") }
 
 @Preview(name = "JumpToBottom — light", showBackground = true, widthDp = 220, heightDp = 80)
 @Composable
+@PreviewLightDark
 fun JetchatJumpToBottomLightPreview() = Wrap {
     Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
         JumpToBottom(enabled = true, onClicked = {}, modifier = Modifier.offset(y = 32.dp))
@@ -361,8 +369,9 @@ fun JetchatJumpToBottomDarkPreview() = Wrap(dark = true) {
 
 @Preview(name = "Conversation — light", showBackground = true, widthDp = 412, heightDp = 800)
 @Composable
+@PreviewLightDark
 fun JetchatConversationContentLightPreview() {
-    JetchatTheme(isDarkTheme = false, isDynamicColor = false) {
+    JetchatTheme(isDynamicColor = false) {
         ConversationContent(uiState = exampleUiState, navigateToProfile = {})
     }
 }
@@ -386,7 +395,7 @@ fun JetchatConversationContentMediumPreview() {
 @Preview(name = "Conversation — empty", showBackground = true, widthDp = 412, heightDp = 800)
 @Composable
 fun JetchatConversationContentEmptyPreview() {
-    JetchatTheme(isDarkTheme = false, isDynamicColor = false) {
+    JetchatTheme(isDynamicColor = false) {
         ConversationContent(
             uiState =
                 ConversationUiState(
@@ -424,6 +433,7 @@ fun JetchatUserInputDarkPreview() = Wrap(dark = true) { UserInput(onMessageSent 
 
 @Preview(name = "EmojiSelector", showBackground = true, widthDp = 412, heightDp = 320)
 @Composable
+@PreviewLightDark
 fun JetchatEmojiSelectorPreview() = Wrap {
     EmojiSelector(onTextAdded = {}, focusRequester = remember { FocusRequester() })
 }
@@ -434,6 +444,7 @@ fun JetchatEmojiTablePreview() = Wrap { EmojiTable(onTextAdded = {}) }
 
 @Preview(name = "SelectorInnerButton — selected", showBackground = true, widthDp = 220)
 @Composable
+@PreviewLightDark
 fun JetchatExtendedSelectorInnerButtonSelectedPreview() = Wrap {
     Row(Modifier.fillMaxWidth()) {
         ExtendedSelectorInnerButton(
@@ -460,6 +471,7 @@ fun JetchatExtendedSelectorInnerButtonUnselectedPreview() = Wrap {
 
 @Preview(name = "FunctionalityNotAvailablePanel", showBackground = true, widthDp = 412, heightDp = 340)
 @Composable
+@PreviewLightDark
 fun JetchatFunctionalityNotAvailablePanelPreview() = Wrap {
     FunctionalityNotAvailablePanel(showImmediately = true)
 }
@@ -470,6 +482,7 @@ fun JetchatFunctionalityNotAvailablePopupPreview() = Wrap { FunctionalityNotAvai
 
 @Preview(name = "RecordButton — idle", showBackground = true, widthDp = 144, heightDp = 144)
 @Composable
+@PreviewLightDark
 fun JetchatRecordButtonIdlePreview() = Wrap {
     Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
         RecordButton(
@@ -504,12 +517,14 @@ fun JetchatRecordButtonRecordingPreview() = Wrap {
 
 @Preview(name = "JetchatIcon", showBackground = true, widthDp = 96, heightDp = 96)
 @Composable
+@PreviewLightDark
 fun JetchatIconPreview() = Wrap {
     JetchatIcon(contentDescription = "Jetchat", modifier = Modifier.size(48.dp))
 }
 
 @Preview(name = "DividerItem", showBackground = true, widthDp = 300, heightDp = 48)
 @Composable
+@PreviewLightDark
 fun JetchatDividerItemPreview() = Wrap {
     Column(Modifier.fillMaxWidth()) {
         Text("Chats", style = MaterialTheme.typography.bodySmall)
@@ -519,6 +534,7 @@ fun JetchatDividerItemPreview() = Wrap {
 
 @Preview(name = "Drawer shell — open", showBackground = true, widthDp = 412, heightDp = 800)
 @Composable
+@PreviewLightDark
 fun JetchatDrawerOpenPreview() {
     // The modal drawer shell (scrim + sheet over the conversation), not just its content.
     JetchatDrawer(
@@ -602,6 +618,7 @@ fun JetchatProfileScreenMediumDarkPreview() {
 
 @Preview(name = "ProfileProperty", showBackground = true, widthDp = 340)
 @Composable
+@PreviewLightDark
 fun JetchatProfilePropertyPreview() = Wrap {
     Column {
         ProfileProperty(label = "Display name", value = meProfile.displayName)
@@ -626,6 +643,7 @@ fun JetchatProfilePropertyAwayPreview() = Wrap {
 
 @Preview(name = "ProfileError", showBackground = true, widthDp = 340, heightDp = 80)
 @Composable
+@PreviewLightDark
 fun JetchatProfileErrorPreview() = Wrap { ProfileError() }
 
 @Preview(name = "ProfileFab — me, extended", showBackground = true, widthDp = 220, heightDp = 96)
@@ -648,6 +666,7 @@ fun JetchatProfileFabOtherCollapsedPreview() = Wrap {
 
 @Preview(name = "AnimatingFabContent — extended", showBackground = true, widthDp = 220, heightDp = 64)
 @Composable
+@PreviewLightDark
 fun JetchatAnimatingFabContentExtendedPreview() = Wrap {
     AnimatingFabContent(
         icon = { Icon(painterResource(id = R.drawable.ic_create), contentDescription = null) },

--- a/Jetchat/app/src/debug/java/com/example/compose/jetchat/catalog/JetchatThemeCatalogs.kt
+++ b/Jetchat/app/src/debug/java/com/example/compose/jetchat/catalog/JetchatThemeCatalogs.kt
@@ -52,13 +52,13 @@ import ee.schimke.composeai.preview.ThemeCatalog
 private fun JetchatScheme(scheme: ColorScheme, content: @Composable () -> Unit) =
     MaterialTheme(colorScheme = scheme, typography = JetchatTypography, content = content)
 
-@ThemeCatalog(name = "Light", group = "Jetchat")
+@ThemeCatalog(name = "Jetchat · Light", group = "Jetchat")
 class JetchatLightThemeCatalog : PreviewWrapperProvider {
     @Composable
     override fun Wrap(content: @Composable () -> Unit) = JetchatScheme(JetchatLightColorScheme, content)
 }
 
-@ThemeCatalog(name = "Dark", group = "Jetchat")
+@ThemeCatalog(name = "Jetchat · Dark", group = "Jetchat")
 class JetchatDarkThemeCatalog : PreviewWrapperProvider {
     @Composable
     override fun Wrap(content: @Composable () -> Unit) = JetchatScheme(JetchatDarkColorScheme, content)

--- a/Jetchat/app/src/main/java/com/example/compose/jetchat/components/JetchatAppBar.kt
+++ b/Jetchat/app/src/main/java/com/example/compose/jetchat/components/JetchatAppBar.kt
@@ -30,6 +30,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.example.compose.jetchat.R
 import com.example.compose.jetchat.theme.JetchatTheme
@@ -63,6 +64,7 @@ fun JetchatAppBar(
 @OptIn(ExperimentalMaterial3Api::class)
 @Preview
 @Composable
+@PreviewLightDark
 fun JetchatAppBarPreview() {
     JetchatTheme {
         JetchatAppBar(title = { Text("Preview!") })

--- a/Jetchat/app/src/main/java/com/example/compose/jetchat/components/JetchatDrawer.kt
+++ b/Jetchat/app/src/main/java/com/example/compose/jetchat/components/JetchatDrawer.kt
@@ -54,6 +54,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.example.compose.jetchat.R
 import com.example.compose.jetchat.data.colleagueProfile
@@ -219,6 +220,7 @@ fun DividerItem(modifier: Modifier = Modifier) {
 
 @Composable
 @Preview
+@PreviewLightDark
 fun DrawerPreview() {
     JetchatTheme {
         Surface {

--- a/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/Conversation.kt
+++ b/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/Conversation.kt
@@ -85,6 +85,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.example.compose.jetchat.FunctionalityNotAvailablePopup
 import com.example.compose.jetchat.R
@@ -548,6 +549,7 @@ fun ConversationPreview() {
 
 @Preview
 @Composable
+@PreviewLightDark
 fun ChannelBarPrev() {
     JetchatTheme {
         ChannelNameBar(channelName = "composers", channelMembers = 52)
@@ -556,8 +558,11 @@ fun ChannelBarPrev() {
 
 @Preview
 @Composable
+@PreviewLightDark
 fun DayHeaderPrev() {
-    DayHeader("Aug 6")
+    JetchatTheme(isDynamicColor = false) {
+        Surface { DayHeader("Aug 6") }
+    }
 }
 
 private val JumpToBottomThreshold = 56.dp

--- a/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/UserInput.kt
+++ b/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/UserInput.kt
@@ -101,10 +101,12 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.example.compose.jetchat.FunctionalityNotAvailablePopup
 import com.example.compose.jetchat.R
+import com.example.compose.jetchat.theme.JetchatTheme
 import kotlin.math.absoluteValue
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
@@ -126,8 +128,11 @@ enum class EmojiStickerSelector {
 
 @Preview
 @Composable
+@PreviewLightDark
 fun UserInputPreview() {
-    UserInput(onMessageSent = {})
+    JetchatTheme(isDynamicColor = false) {
+        UserInput(onMessageSent = {})
+    }
 }
 
 @OptIn(ExperimentalFoundationApi::class)

--- a/Jetchat/app/src/main/java/com/example/compose/jetchat/profile/Previews.kt
+++ b/Jetchat/app/src/main/java/com/example/compose/jetchat/profile/Previews.kt
@@ -18,12 +18,14 @@ package com.example.compose.jetchat.profile
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.example.compose.jetchat.data.colleagueProfile
 import com.example.compose.jetchat.data.meProfile
 import com.example.compose.jetchat.theme.JetchatTheme
 
 @Preview(device = "spec:width=340dp,height=800dp,dpi=160", name = "340 width - Me")
 @Composable
+@PreviewLightDark
 fun ProfilePreview340() {
     JetchatTheme {
         ProfileScreen(meProfile)

--- a/Jetchat/app/src/main/java/com/example/compose/jetchat/profile/Profile.kt
+++ b/Jetchat/app/src/main/java/com/example/compose/jetchat/profile/Profile.kt
@@ -59,6 +59,7 @@ import androidx.compose.ui.platform.rememberNestedScrollInteropConnection
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.example.compose.jetchat.FunctionalityNotAvailablePopup
@@ -287,6 +288,7 @@ fun ConvPreviewPortraitOtherDefault() {
 
 @Preview
 @Composable
+@PreviewLightDark
 fun ProfileFabPreview() {
     JetchatTheme {
         ProfileFab(extended = true, userIsMe = false)

--- a/Jetsnack/app/src/debug/java/com/example/jetsnack/catalog/JetsnackComponentPreviews.kt
+++ b/Jetsnack/app/src/debug/java/com/example/jetsnack/catalog/JetsnackComponentPreviews.kt
@@ -50,6 +50,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.example.jetsnack.R
 import com.example.jetsnack.model.Filter
@@ -123,6 +124,7 @@ private fun Wrap(content: @Composable () -> Unit) = JetsnackPreviewWrapper {
 @Preview("default")
 @Preview("dark theme", uiMode = UI_MODE_NIGHT_YES)
 @Composable
+@PreviewLightDark
 fun JetsnackSurfaceFlatPreview() = Wrap {
     JetsnackSurface(shape = RoundedCornerShape(12.dp), elevation = 0.dp) {
         Text("Flat surface — elevation 0dp", Modifier.padding(16.dp))
@@ -196,6 +198,7 @@ private class PreviewSnackbarData(override val visuals: SnackbarVisuals) : Snack
 @Preview("default")
 @Preview("dark theme", uiMode = UI_MODE_NIGHT_YES)
 @Composable
+@PreviewLightDark
 fun JetsnackSnackbarPreview() = Wrap {
     JetsnackSnackbar(
         snackbarData = PreviewSnackbarData(
@@ -230,6 +233,7 @@ private fun GridCell(index: Int) {
 
 @Preview("default")
 @Composable
+@PreviewLightDark
 fun VerticalGridTwoColumnPreview() = Wrap {
     VerticalGrid(columns = 2) { repeat(6) { GridCell(it) } }
 }
@@ -245,12 +249,14 @@ fun VerticalGridThreeColumnPreview() = Wrap {
 @Preview("default")
 @Preview("dark theme", uiMode = UI_MODE_NIGHT_YES)
 @Composable
+@PreviewLightDark
 fun SnackItemPreview() = Wrap {
     SnackItem(snack = snack, snackCollectionId = 1L, onSnackClick = { _, _ -> })
 }
 
 @Preview("default")
 @Composable
+@PreviewLightDark
 fun SnackImagePreview() = Wrap {
     SnackImage(
         imageRes = snack.imageRes,
@@ -263,6 +269,7 @@ fun SnackImagePreview() = Wrap {
 @Preview("default", heightDp = 320)
 @Preview("dark theme", uiMode = UI_MODE_NIGHT_YES, heightDp = 320)
 @Composable
+@PreviewLightDark
 fun SnackCollectionHighlightPreview() = Wrap {
     SnackCollection(
         snackCollection = SnackRepo.getSnacks().first(),
@@ -286,6 +293,7 @@ fun SnackCollectionNormalPreview() = Wrap {
 @Preview("default")
 @Preview("dark theme", uiMode = UI_MODE_NIGHT_YES)
 @Composable
+@PreviewLightDark
 fun FilterBarPreview() = Wrap {
     FilterBar(
         filters = previewFilters(),
@@ -334,6 +342,7 @@ private fun previewFilters() = listOf(
 @Preview("default")
 @Preview("dark theme", uiMode = UI_MODE_NIGHT_YES)
 @Composable
+@PreviewLightDark
 fun CartItemPreview() = Wrap {
     CartItem(
         orderLine = cart.first(),
@@ -371,12 +380,14 @@ fun CartItemManyPreview() = Wrap {
 @Preview("default")
 @Preview("dark theme", uiMode = UI_MODE_NIGHT_YES)
 @Composable
+@PreviewLightDark
 fun SummaryItemPreview() = Wrap {
     SummaryItem(subtotal = 134500L, shippingCosts = 36000L)
 }
 
 @Preview("default")
 @Composable
+@PreviewLightDark
 fun SwipeDismissItemPreview() = Wrap {
     SwipeDismissItem(
         background = { progress ->
@@ -406,6 +417,7 @@ fun SwipeDismissItemPreview() = Wrap {
 
 @Preview("catalog")
 @Composable
+@PreviewLightDark
 fun SearchBarCatalogPreview() = Wrap {
     SearchBar(
         query = TextFieldValue(),
@@ -468,6 +480,7 @@ fun SearchBarLargeFontCatalogPreview() = SearchBarCatalogPreview()
 @Preview("dark theme", uiMode = UI_MODE_NIGHT_YES)
 @Preview("large font", fontScale = 2f, widthDp = 412, heightDp = 220)
 @Composable
+@PreviewLightDark
 fun SearchCategoryCatalogPreview() = Wrap {
     SearchCategory(
         category = SearchCategoryModel(
@@ -487,6 +500,7 @@ fun SearchCategoriesPreview() = Wrap {
 
 @Preview("default", heightDp = 400)
 @Composable
+@PreviewLightDark
 fun SearchSuggestionsPreview() = Wrap {
     SearchSuggestions(
         suggestions = SearchRepo.getSuggestions(),
@@ -506,6 +520,7 @@ fun SearchSuggestionsLargeFontPreview() = SearchSuggestionsPreview()
 @Preview("dark theme", uiMode = UI_MODE_NIGHT_YES)
 @Preview("large font", fontScale = 2f, widthDp = 412, heightDp = 220)
 @Composable
+@PreviewLightDark
 fun SearchResultCatalogPreview() = Wrap {
     SearchResult(
         snack = snacks[0],
@@ -534,12 +549,14 @@ fun SearchResultsPreview() = Wrap {
 @Preview("default")
 @Preview("dark theme", uiMode = UI_MODE_NIGHT_YES)
 @Composable
+@PreviewLightDark
 fun NoResultsPreview() = Wrap {
     NoResults(query = "kombucha")
 }
 
 @Preview("catalog", device = "spec:width=400dp,height=800dp,dpi=160")
 @Composable
+@PreviewLightDark
 fun SnackDetailCatalogPreview() {
     JetsnackPreviewWrapper {
         SnackDetail(
@@ -580,6 +597,7 @@ private fun BottomBar(current: HomeSections) = Wrap {
 @Preview("default")
 @Preview("dark theme", uiMode = UI_MODE_NIGHT_YES)
 @Composable
+@PreviewLightDark
 fun JetsnackBottomBarFeedPreview() = BottomBar(HomeSections.FEED)
 
 @Preview("default")
@@ -620,6 +638,7 @@ private fun NavItem(selected: Boolean) = Wrap {
 
 @Preview("default", device = "spec:width=400dp,height=800dp,dpi=160")
 @Composable
+@PreviewLightDark
 fun JetsnackBottomNavigationItemSelectedPreview() = NavItem(selected = true)
 
 @Preview("default", device = "spec:width=400dp,height=800dp,dpi=160")
@@ -672,8 +691,9 @@ private fun ColorTokens(colors: JetsnackColors) = ProvideJetsnackColors(colors) 
 
 @Preview("light tokens", heightDp = 560)
 @Composable
-fun JetsnackColorTokensLightPreview() = JetsnackTheme(darkTheme = false) {
-    ColorTokens(LightColorPalette)
+@PreviewLightDark
+fun JetsnackColorTokensLightPreview() = JetsnackTheme {
+    ColorTokens(JetsnackTheme.colors)
 }
 
 @Preview("dark tokens", heightDp = 560)
@@ -715,8 +735,9 @@ private fun GradientTokens(colors: JetsnackColors) = ProvideJetsnackColors(color
 
 @Preview("light gradients", heightDp = 470)
 @Composable
-fun JetsnackGradientTokensPreview() = JetsnackTheme(darkTheme = false) {
-    GradientTokens(LightColorPalette)
+@PreviewLightDark
+fun JetsnackGradientTokensPreview() = JetsnackTheme {
+    GradientTokens(JetsnackTheme.colors)
 }
 
 @Preview("dark gradients", heightDp = 470)

--- a/Jetsnack/app/src/debug/java/com/example/jetsnack/catalog/JetsnackScreenPreviews.kt
+++ b/Jetsnack/app/src/debug/java/com/example/jetsnack/catalog/JetsnackScreenPreviews.kt
@@ -21,6 +21,7 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.SharedTransitionLayout
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.example.jetsnack.model.SnackRepo
 import com.example.jetsnack.ui.components.JetsnackPreviewWrapper
 import com.example.jetsnack.ui.home.Feed
@@ -45,6 +46,7 @@ import com.example.jetsnack.ui.home.search.Search
     device = "spec:width=700dp,height=800dp,dpi=160",
 )
 @Composable
+@PreviewLightDark
 fun FeedScreenPreview() = JetsnackPreviewWrapper {
     Feed(onSnackClick = { _, _ -> })
 }
@@ -61,6 +63,7 @@ fun FeedScreenPreview() = JetsnackPreviewWrapper {
     device = "spec:width=700dp,height=800dp,dpi=160",
 )
 @Composable
+@PreviewLightDark
 fun CartScreenPreview() = JetsnackPreviewWrapper {
     Cart(
         orderLines = SnackRepo.getCart(),
@@ -89,6 +92,7 @@ fun CartScreenEmptyPreview() = JetsnackPreviewWrapper {
 @Preview("dark theme", uiMode = UI_MODE_NIGHT_YES)
 @Preview("large font", fontScale = 2f, widthDp = 412, heightDp = 800)
 @Composable
+@PreviewLightDark
 fun ProfileScreenPreview() = JetsnackPreviewWrapper {
     Profile()
 }
@@ -100,12 +104,14 @@ fun ProfileScreenPreview() = JetsnackPreviewWrapper {
     device = "spec:width=400dp,height=800dp,dpi=160",
 )
 @Composable
+@PreviewLightDark
 fun SearchScreenPreview() = JetsnackPreviewWrapper {
     Search(onSnackClick = { _, _ -> })
 }
 
 @Preview("filter screen")
 @Composable
+@PreviewLightDark
 fun FilterScreenCatalogPreview() = JetsnackPreviewWrapper {
     SharedTransitionLayout {
         AnimatedVisibility(true) {

--- a/Jetsnack/app/src/debug/java/com/example/jetsnack/catalog/JetsnackThemeCatalogs.kt
+++ b/Jetsnack/app/src/debug/java/com/example/jetsnack/catalog/JetsnackThemeCatalogs.kt
@@ -98,13 +98,13 @@ private fun JetsnackPalette(colors: JetsnackColors, content: @Composable () -> U
     )
 }
 
-@ThemeCatalog(name = "Light", group = "Jetsnack")
+@ThemeCatalog(name = "Jetsnack · Light", group = "Jetsnack")
 class JetsnackLightThemeCatalog : PreviewWrapperProvider {
     @Composable
     override fun Wrap(content: @Composable () -> Unit) = JetsnackPalette(LightColorPalette, content)
 }
 
-@ThemeCatalog(name = "Dark", group = "Jetsnack")
+@ThemeCatalog(name = "Jetsnack · Dark", group = "Jetsnack")
 class JetsnackDarkThemeCatalog : PreviewWrapperProvider {
     @Composable
     override fun Wrap(content: @Composable () -> Unit) = JetsnackPalette(DarkColorPalette, content)

--- a/Jetsnack/app/src/main/java/com/example/jetsnack/ui/JetsnackApp.kt
+++ b/Jetsnack/app/src/main/java/com/example/jetsnack/ui/JetsnackApp.kt
@@ -38,6 +38,7 @@ import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
@@ -59,6 +60,7 @@ import com.example.jetsnack.ui.theme.JetsnackTheme
 
 @Preview(device = "spec:width=400dp,height=800dp,dpi=160")
 @Composable
+@PreviewLightDark
 fun JetsnackApp() {
     JetsnackTheme {
         val jetsnackNavController = rememberJetsnackNavController()

--- a/Jetsnack/app/src/main/java/com/example/jetsnack/ui/components/Button.kt
+++ b/Jetsnack/app/src/main/java/com/example/jetsnack/ui/components/Button.kt
@@ -45,6 +45,7 @@ import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.example.jetsnack.ui.theme.JetsnackTheme
 
 @Composable
@@ -107,6 +108,7 @@ private val ButtonShape = RoundedCornerShape(percent = 50)
 @Preview("dark theme", "round", uiMode = UI_MODE_NIGHT_YES)
 @Preview("large font", "round", fontScale = 2f, widthDp = 412, heightDp = 120)
 @Composable
+@PreviewLightDark
 private fun ButtonPreview() {
     JetsnackTheme {
         JetsnackButton(onClick = {}) {

--- a/Jetsnack/app/src/main/java/com/example/jetsnack/ui/components/Card.kt
+++ b/Jetsnack/app/src/main/java/com/example/jetsnack/ui/components/Card.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.example.jetsnack.ui.theme.JetsnackTheme
@@ -55,6 +56,7 @@ fun JetsnackCard(
 @Preview("dark theme", uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Preview("large font", fontScale = 2f, widthDp = 412, heightDp = 180)
 @Composable
+@PreviewLightDark
 private fun CardPreview() {
     JetsnackTheme {
         JetsnackCard {

--- a/Jetsnack/app/src/main/java/com/example/jetsnack/ui/components/Divider.kt
+++ b/Jetsnack/app/src/main/java/com/example/jetsnack/ui/components/Divider.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.example.jetsnack.ui.theme.JetsnackTheme
@@ -47,6 +48,7 @@ private const val DividerAlpha = 0.12f
 @Preview("default", showBackground = true)
 @Preview("dark theme", uiMode = Configuration.UI_MODE_NIGHT_YES, showBackground = true)
 @Composable
+@PreviewLightDark
 private fun DividerPreview() {
     JetsnackTheme {
         Box(Modifier.size(height = 10.dp, width = 100.dp)) {

--- a/Jetsnack/app/src/main/java/com/example/jetsnack/ui/components/Filters.kt
+++ b/Jetsnack/app/src/main/java/com/example/jetsnack/ui/components/Filters.kt
@@ -49,6 +49,7 @@ import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.example.jetsnack.R
 import com.example.jetsnack.model.Filter
@@ -174,6 +175,7 @@ private fun FilterDisabledPreview() {
 @Preview("dark theme", uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Preview("large font", fontScale = 2f, widthDp = 412, heightDp = 120)
 @Composable
+@PreviewLightDark
 private fun FilterEnabledPreview() {
     JetsnackTheme {
         FilterChip(Filter(name = "Demo", enabled = true))

--- a/Jetsnack/app/src/main/java/com/example/jetsnack/ui/components/GradientTintedIconButton.kt
+++ b/Jetsnack/app/src/main/java/com/example/jetsnack/ui/components/GradientTintedIconButton.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.example.jetsnack.R
 import com.example.jetsnack.ui.theme.JetsnackTheme
@@ -98,6 +99,7 @@ fun JetsnackGradientTintedIconButton(
 @Preview("default")
 @Preview("dark theme", uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
+@PreviewLightDark
 private fun GradientTintedIconButtonPreview() {
     JetsnackTheme {
         JetsnackGradientTintedIconButton(

--- a/Jetsnack/app/src/main/java/com/example/jetsnack/ui/components/QuantitySelector.kt
+++ b/Jetsnack/app/src/main/java/com/example/jetsnack/ui/components/QuantitySelector.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -83,6 +84,7 @@ fun QuantitySelector(count: Int, decreaseItemCount: () -> Unit, increaseItemCoun
 @Preview("dark theme", uiMode = UI_MODE_NIGHT_YES)
 @Preview("large font", fontScale = 2f, widthDp = 412, heightDp = 120)
 @Composable
+@PreviewLightDark
 fun QuantitySelectorPreview() {
     JetsnackTheme {
         JetsnackSurface {

--- a/Jetsnack/app/src/main/java/com/example/jetsnack/ui/components/Snacks.kt
+++ b/Jetsnack/app/src/main/java/com/example/jetsnack/ui/components/Snacks.kt
@@ -67,6 +67,7 @@ import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -477,6 +478,7 @@ fun SnackImage(
 @Preview("dark theme", uiMode = UI_MODE_NIGHT_YES)
 @Preview("large font", fontScale = 2f, widthDp = 412, heightDp = 300)
 @Composable
+@PreviewLightDark
 fun SnackCardPreview() {
     val snack = snacks.first()
     JetsnackPreviewWrapper {

--- a/Jetsnack/app/src/main/java/com/example/jetsnack/ui/home/DestinationBar.kt
+++ b/Jetsnack/app/src/main/java/com/example/jetsnack/ui/home/DestinationBar.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.example.jetsnack.R
 import com.example.jetsnack.ui.LocalNavAnimatedVisibilityScope
 import com.example.jetsnack.ui.LocalSharedTransitionScope
@@ -110,6 +111,7 @@ fun DestinationBar(modifier: Modifier = Modifier) {
 @Preview("dark theme", uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Preview("large font", fontScale = 2f, widthDp = 412, heightDp = 160)
 @Composable
+@PreviewLightDark
 fun PreviewDestinationBar() {
     JetsnackPreviewWrapper {
         DestinationBar()

--- a/Reply/app/src/debug/java/com/example/reply/catalog/ReplyComponentPreviews.kt
+++ b/Reply/app/src/debug/java/com/example/reply/catalog/ReplyComponentPreviews.kt
@@ -17,6 +17,7 @@
 package com.example.reply.catalog
 
 import android.content.res.Configuration
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -25,6 +26,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.example.reply.data.local.LocalEmailsDataProvider
 import com.example.reply.ui.ReplyEmailDetail
@@ -63,7 +65,7 @@ private val threadEmail = LocalEmailsDataProvider.allEmails[1]
 private val emails = LocalEmailsDataProvider.allEmails
 
 @Composable
-private fun Wrap(dark: Boolean = false, content: @Composable () -> Unit) = ContrastAwareReplyTheme(darkTheme = dark) {
+private fun Wrap(dark: Boolean = isSystemInDarkTheme(), content: @Composable () -> Unit) = ContrastAwareReplyTheme(darkTheme = dark) {
     Surface { Box(Modifier.padding(8.dp)) { content() } }
 }
 
@@ -71,6 +73,7 @@ private fun Wrap(dark: Boolean = false, content: @Composable () -> Unit) = Contr
 
 @Preview(name = "ProfileImage", showBackground = true)
 @Composable
+@PreviewLightDark
 fun ReplyProfileImagePreview() = Wrap {
     ReplyProfileImage(email.sender.avatar, email.sender.fullName, Modifier.padding(4.dp))
 }
@@ -83,6 +86,7 @@ fun SelectedProfileImagePreview() = Wrap { SelectedProfileImage(Modifier.padding
 
 @Preview(name = "EmailListItem", showBackground = true, widthDp = 400)
 @Composable
+@PreviewLightDark
 fun ReplyEmailListItemPreview() = Wrap {
     ReplyEmailListItem(email = email, navigateToDetail = {}, toggleSelection = {})
 }
@@ -121,6 +125,7 @@ fun ReplyEmailListItemDarkPreview() = Wrap(dark = true) {
 
 @Preview(name = "EmailThreadItem", showBackground = true, widthDp = 400)
 @Composable
+@PreviewLightDark
 fun ReplyEmailThreadItemPreview() = Wrap { ReplyEmailThreadItem(email = threadEmail) }
 
 @Preview(name = "EmailThreadItem — dark", showBackground = true, widthDp = 400, uiMode = Configuration.UI_MODE_NIGHT_YES)
@@ -133,6 +138,7 @@ fun ReplyEmailThreadItemDarkPreview() = Wrap(dark = true) {
 
 @Preview(name = "SearchBar", showBackground = true, widthDp = 400)
 @Composable
+@PreviewLightDark
 fun ReplyDockedSearchBarPreview() = Wrap {
     ReplyDockedSearchBar(emails = emails, onSearchItemSelected = {})
 }
@@ -160,6 +166,7 @@ fun ReplyDockedSearchBarResultsPreview() = Wrap {
 
 @Preview(name = "DetailAppBar — full screen", showBackground = true, widthDp = 400)
 @Composable
+@PreviewLightDark
 fun EmailDetailAppBarFullScreenPreview() = Wrap {
     EmailDetailAppBar(email = email, isFullScreen = true, onBackPressed = {})
 }
@@ -174,6 +181,7 @@ fun EmailDetailAppBarPanePreview() = Wrap {
 
 @Preview(name = "EmailList", showBackground = true, widthDp = 400, heightDp = 700)
 @Composable
+@PreviewLightDark
 fun ReplyEmailListPreview() = Wrap {
     ReplyEmailList(
         emails = emails,
@@ -213,6 +221,7 @@ fun ReplyEmailListEmptyPreview() = Wrap {
 
 @Preview(name = "EmailDetail — full screen", showBackground = true, widthDp = 400, heightDp = 700)
 @Composable
+@PreviewLightDark
 fun ReplyEmailDetailPreview() = Wrap {
     ReplyEmailDetail(email = email, modifier = Modifier.fillMaxSize())
 }
@@ -233,6 +242,7 @@ fun ReplyEmailDetailDarkPreview() = Wrap(dark = true) {
 
 @Preview(name = "BottomNavigationBar", showBackground = true, widthDp = 400)
 @Composable
+@PreviewLightDark
 fun ReplyBottomNavigationBarPreview() = Wrap {
     ReplyBottomNavigationBar(currentDestination = null, navigateToTopLevelDestination = {})
 }
@@ -259,6 +269,7 @@ fun ReplyBottomNavigationBarArticlesPreview() = Wrap {
 
 @Preview(name = "NavigationRail — top", showBackground = true, widthDp = 120, heightDp = 600)
 @Composable
+@PreviewLightDark
 fun ReplyNavigationRailTopPreview() = Wrap {
     ReplyNavigationRail(
         currentDestination = null,
@@ -290,6 +301,7 @@ fun ReplyNavigationRailInboxPreview() = Wrap {
 
 @Preview(name = "PermanentDrawer", showBackground = true, widthDp = 300, heightDp = 700)
 @Composable
+@PreviewLightDark
 fun PermanentNavigationDrawerContentPreview() = Wrap {
     PermanentNavigationDrawerContent(
         currentDestination = null,

--- a/Reply/app/src/debug/java/com/example/reply/catalog/ReplyThemeCatalogs.kt
+++ b/Reply/app/src/debug/java/com/example/reply/catalog/ReplyThemeCatalogs.kt
@@ -51,13 +51,13 @@ import ee.schimke.composeai.preview.ThemeCatalog
 @Composable private fun ReplyScheme(scheme: androidx.compose.material3.ColorScheme, content: @Composable () -> Unit) =
     MaterialTheme(colorScheme = scheme, typography = replyTypography, shapes = shapes, content = content)
 
-@ThemeCatalog(name = "Light", group = "Reply")
+@ThemeCatalog(name = "Reply · Light", group = "Reply")
 class ReplyLightThemeCatalog : PreviewWrapperProvider {
     @Composable
     override fun Wrap(content: @Composable () -> Unit) = ReplyScheme(lightScheme, content)
 }
 
-@ThemeCatalog(name = "Dark", group = "Reply")
+@ThemeCatalog(name = "Reply · Dark", group = "Reply")
 class ReplyDarkThemeCatalog : PreviewWrapperProvider {
     @Composable
     override fun Wrap(content: @Composable () -> Unit) = ReplyScheme(darkScheme, content)

--- a/Reply/app/src/main/java/com/example/reply/ui/EmptyComingSoon.kt
+++ b/Reply/app/src/main/java/com/example/reply/ui/EmptyComingSoon.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -28,8 +29,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.example.reply.R
+import com.example.reply.ui.theme.ContrastAwareReplyTheme
 
 @Composable
 fun EmptyComingSoon(modifier: Modifier = Modifier) {
@@ -57,6 +60,9 @@ fun EmptyComingSoon(modifier: Modifier = Modifier) {
 
 @Preview
 @Composable
+@PreviewLightDark
 fun ComingSoonPreview() {
-    EmptyComingSoon()
+    ContrastAwareReplyTheme {
+        Surface { EmptyComingSoon() }
+    }
 }

--- a/Reply/app/src/main/java/com/example/reply/ui/MainActivity.kt
+++ b/Reply/app/src/main/java/com/example/reply/ui/MainActivity.kt
@@ -27,6 +27,7 @@ import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -71,6 +72,7 @@ class MainActivity : ComponentActivity() {
 @OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
 @Preview(showBackground = true)
 @Composable
+@PreviewLightDark
 fun ReplyAppPreview() {
     ContrastAwareReplyTheme {
         ReplyApp(


### PR DESCRIPTION
## Goal

Fix the compose-samples Light/Dark catalog issues reported in yschimke/compose-ai-tools#3267, scoped to this project.

## Summary

- Add `@PreviewLightDark` coverage to all 127 primary catalog previews across JetNews, Jetcaster, Jetchat, Jetsnack, JetLagged, and Reply.
- Make preview wrappers and fixed-color specimens derive their colors from the active preview configuration.
- Qualify each app's theme-provider labels so they do not collide with generic Light/Dark controls.
- No abandoned implementation remains.
- Known gap: module-wide rendering still reports the pre-existing Jetchat Glance invocation failures and JetLagged default-parameter preview failures already documented by their catalogs. The requested catalog previews render successfully.

Verification:
- `compileDebugKotlin` completed for all six apps.
- Spotless checks/application completed for all changed modules.
- Full artifact hash audit: 127/127 Light/Dark pairs are present and visually distinct.
- Representative rendered pairs:
  - JetNews: `PreviewHomeListDrawerScreen_Light` / `PreviewHomeListDrawerScreen_Dark`
  - Jetcaster: `JetcasterHomeDiscoverPreview_Light` / `JetcasterHomeDiscoverPreview_Dark`
  - Jetchat: `JetchatMessageOtherPreview_Light` / `JetchatMessageOtherPreview_Dark`
  - Jetsnack: `FeedScreenPreview_Light` / `FeedScreenPreview_Dark`
  - JetLagged: `JetLaggedScreenCompactPreview_Light` / `JetLaggedScreenCompactPreview_Dark`
  - Reply: `ReplyEmailListPreview_Light` / `ReplyEmailListPreview_Dark`

Addresses yschimke/compose-ai-tools#3267 (compose-samples scope).