### PR TITLE
Bump catalog tooling to 0.19.31

### DIFF
--- a/JetLagged/gradle/libs.versions.toml
+++ b/JetLagged/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-composeAiPreview = "0.19.30"
+composeAiPreview = "0.19.31"
 accompanist = "0.37.3"
 android-material3 = "1.14.0"
 androidGradlePlugin = "9.2.1"

--- a/JetNews/gradle/libs.versions.toml
+++ b/JetNews/gradle/libs.versions.toml
@@ -4,7 +4,7 @@
 #####
 [versions]
 accompanist = "0.37.3"
-composeAiPreview = "0.19.30"
+composeAiPreview = "0.19.31"
 android-material3 = "1.14.0"
 androidGradlePlugin = "9.2.1"
 androidx-activity-compose = "1.13.0"

--- a/Jetcaster/gradle/libs.versions.toml
+++ b/Jetcaster/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 # Do not add a dependency to an individual sample, edit the global version instead.
 #####
 [versions]
-composeAiPreview = "0.19.30"
+composeAiPreview = "0.19.31"
 accompanist = "0.37.3"
 android-material3 = "1.14.0"
 androidGradlePlugin = "9.2.1"

--- a/Jetchat/gradle/libs.versions.toml
+++ b/Jetchat/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 # Do not add a dependency to an individual sample, edit the global version instead.
 #####
 [versions]
-composeAiPreview = "0.19.30"
+composeAiPreview = "0.19.31"
 accompanist = "0.37.3"
 android-material3 = "1.14.0"
 androidGradlePlugin = "9.2.1"

--- a/Jetsnack/gradle/libs.versions.toml
+++ b/Jetsnack/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-composeAiPreview = "0.19.30"
+composeAiPreview = "0.19.31"
 accompanist = "0.37.3"
 android-material3 = "1.14.0"
 androidGradlePlugin = "9.2.1"

--- a/Reply/gradle/libs.versions.toml
+++ b/Reply/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 # Do not add a dependency to an individual sample, edit the global version instead.
 #####
 [versions]
-composeAiPreview = "0.19.30"
+composeAiPreview = "0.19.31"
 accompanist = "0.37.3"
 android-material3 = "1.14.0"
 androidGradlePlugin = "9.2.1"


### PR DESCRIPTION
## What changed

- Advance the compose-ai-tools Gradle plugin and preview annotations from 0.19.30 to 0.19.31 in JetNews, Jetcaster, Jetchat, Jetsnack, JetLagged, and Reply.
- Keep the design-artifacts driver on the released toolchain carrying design-parity 0.1.38.

## Why

PR #20 landed the initial 0.19.30 bump. The preceding regeneration run, [30898023245](https://github.com/yschimke/compose-samples/actions/runs/30898023245), exposed two upstream generator issues:

- duplicate output axes while folding Light/Dark multipreviews in JetNews, Jetcaster, Jetchat, and Jetsnack;
- conflicting `annotations/index.json` assets while folding Material 3 into JetLagged and Reply.

compose-ai-tools 0.19.31 contains the multipreview selection fix, while 0.19.30 already contains the annotation-manifest merge fix. Merging this PR into `previews` triggers regeneration and republication of all six catalogs.

## Verification

- `:app:compileDebugKotlin` passed against published 0.19.31 artifacts for JetNews, Jetchat, Jetsnack, JetLagged, and Reply.
- `:mobile:compileDebugKotlin` passed against published 0.19.31 artifacts for Jetcaster.
- Maven Central and the public GitHub release both serve 0.19.31.
- `git diff --check` passed.