### PR TITLE
Fix duplicate catalog theme axes

### DIFF
--- a/JetNews/app/src/debug/java/com/example/jetnews/catalog/JetnewsAnimationPreviews.kt
+++ b/JetNews/app/src/debug/java/com/example/jetnews/catalog/JetnewsAnimationPreviews.kt
@@ -72,12 +72,6 @@ import kotlinx.coroutines.delay
  * on the sticker sheet.
  */
 @Preview(name = "Popular post card", showBackground = true, widthDp = 280)
-@Preview(
-    name = "Popular post card (dark)",
-    showBackground = true,
-    widthDp = 280,
-    uiMode = Configuration.UI_MODE_NIGHT_YES,
-)
 @Composable
 @PreviewLightDark
 fun PopularPostCardCatalogPreview() {

--- a/JetNews/app/src/main/java/com/example/jetnews/ui/AppDrawer.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/AppDrawer.kt
@@ -96,7 +96,6 @@ private fun JetNewsLogo(modifier: Modifier = Modifier) {
 }
 
 @Preview("Drawer contents")
-@Preview("Drawer contents (dark)", uiMode = UI_MODE_NIGHT_YES)
 @Composable
 @PreviewLightDark
 fun PreviewAppDrawer() {

--- a/JetNews/app/src/main/java/com/example/jetnews/ui/components/AppNavRail.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/components/AppNavRail.kt
@@ -80,7 +80,6 @@ fun AppNavRail(
 }
 
 @Preview("Drawer contents")
-@Preview("Drawer contents (dark)", uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 @PreviewLightDark
 fun PreviewAppNavRail() {

--- a/JetNews/app/src/main/java/com/example/jetnews/ui/home/HomeScreens.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/home/HomeScreens.kt
@@ -666,7 +666,6 @@ private fun HomeTopAppBar(
 }
 
 @Preview("Home list drawer screen")
-@Preview("Home list drawer screen (dark)", uiMode = UI_MODE_NIGHT_YES)
 @Preview(
     "Home list drawer screen (big font)",
     fontScale = 1.5f,

--- a/JetNews/app/src/main/java/com/example/jetnews/ui/home/PostCardTop.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/home/PostCardTop.kt
@@ -89,7 +89,7 @@ fun PostCardTop(post: Post, modifier: Modifier = Modifier) {
  *
  * Learn more about Preview features in the [documentation](https://d.android.com/jetpack/compose/tooling#preview)
  */
-@Preview
+@Preview(name = "Post card top")
 @Composable
 @PreviewLightDark
 fun PostCardTopPreview() {

--- a/JetNews/app/src/main/java/com/example/jetnews/ui/home/PostCards.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/home/PostCards.kt
@@ -214,7 +214,6 @@ fun BookmarkButtonBookmarkedPreview() {
 }
 
 @Preview("Simple post card")
-@Preview("Simple post card (dark)", uiMode = UI_MODE_NIGHT_YES)
 @Composable
 @PreviewLightDark
 fun SimplePostPreview() {

--- a/JetNews/app/src/main/java/com/example/jetnews/ui/interests/InterestsScreen.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/interests/InterestsScreen.kt
@@ -552,7 +552,6 @@ private fun InterestsAdaptiveContentLayout(
 }
 
 @Preview("Interests screen", "Interests")
-@Preview("Interests screen (dark)", "Interests", uiMode = UI_MODE_NIGHT_YES)
 @Preview(
     "Interests screen (big font)", "Interests",
     fontScale = 1.5f, widthDp = 412, heightDp = 900,
@@ -606,7 +605,6 @@ fun PreviewInterestsScreenNavRail() {
 }
 
 @Preview("Interests screen topics tab", "Topics")
-@Preview("Interests screen topics tab (dark)", "Topics", uiMode = UI_MODE_NIGHT_YES)
 @Composable
 @PreviewLightDark
 fun PreviewTopicsTab() {
@@ -621,7 +619,6 @@ fun PreviewTopicsTab() {
 }
 
 @Preview("Interests screen people tab", "People")
-@Preview("Interests screen people tab (dark)", "People", uiMode = UI_MODE_NIGHT_YES)
 @Composable
 @PreviewLightDark
 fun PreviewPeopleTab() {

--- a/JetNews/app/src/main/java/com/example/jetnews/ui/interests/SelectTopicButton.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/interests/SelectTopicButton.kt
@@ -68,7 +68,6 @@ fun SelectTopicButton(modifier: Modifier = Modifier, selected: Boolean = false) 
 }
 
 @Preview("Off")
-@Preview("Off (dark)", uiMode = UI_MODE_NIGHT_YES)
 @Composable
 @PreviewLightDark
 fun SelectTopicButtonPreviewOff() {

--- a/JetNews/app/src/main/java/com/example/jetnews/ui/post/PostContent.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/post/PostContent.kt
@@ -331,7 +331,6 @@ private val ColorScheme.codeBlockBackground: Color
     get() = onSurface.copy(alpha = .15f)
 
 @Preview("Post content")
-@Preview("Post content (dark)", uiMode = UI_MODE_NIGHT_YES)
 @Composable
 @PreviewLightDark
 fun PreviewPost() {

--- a/JetNews/app/src/main/java/com/example/jetnews/ui/post/PostScreen.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/post/PostScreen.kt
@@ -403,7 +403,6 @@ fun sharePost(post: Post, context: Context) {
 }
 
 @Preview("Post screen")
-@Preview("Post screen (dark)", uiMode = UI_MODE_NIGHT_YES)
 @Preview("Post screen (big font)", fontScale = 1.5f, widthDp = 412, heightDp = 900)
 @Composable
 @PreviewLightDark

--- a/Jetcaster/mobile/src/main/java/com/example/jetcaster/ui/home/Home.kt
+++ b/Jetcaster/mobile/src/main/java/com/example/jetcaster/ui/home/Home.kt
@@ -220,7 +220,7 @@ internal fun HomeScreenError(onRetry: () -> Unit, modifier: Modifier = Modifier)
     }
 }
 
-@Preview
+@Preview(name = "Home screen error")
 @Composable
 @PreviewLightDark
 fun HomeScreenErrorPreview() {
@@ -743,7 +743,7 @@ private fun lastUpdated(updated: OffsetDateTime): String {
     }
 }
 
-@Preview
+@Preview(name = "Home app bar")
 @Composable
 @PreviewLightDark
 private fun HomeAppBarPreview() {
@@ -783,7 +783,7 @@ private fun PreviewHome() {
 }
 
 @Composable
-@Preview
+@Preview(name = "Podcast card")
 @PreviewLightDark
 private fun PreviewPodcastCard() {
     JetcasterTheme {

--- a/Jetcaster/mobile/src/main/java/com/example/jetcaster/ui/player/PlayerScreen.kt
+++ b/Jetcaster/mobile/src/main/java/com/example/jetcaster/ui/player/PlayerScreen.kt
@@ -879,7 +879,7 @@ private fun FullScreenLoading(modifier: Modifier = Modifier) {
     }
 }
 
-@Preview
+@Preview(name = "Player top app bar")
 @Composable
 @PreviewLightDark
 fun TopAppBarPreview() {
@@ -893,7 +893,7 @@ fun TopAppBarPreview() {
     }
 }
 
-@Preview
+@Preview(name = "Player buttons")
 @Composable
 @PreviewLightDark
 fun PlayerButtonsPreview() {

--- a/Jetcaster/mobile/src/main/java/com/example/jetcaster/ui/podcast/PodcastDetailsScreen.kt
+++ b/Jetcaster/mobile/src/main/java/com/example/jetcaster/ui/podcast/PodcastDetailsScreen.kt
@@ -384,7 +384,7 @@ fun PodcastDetailsTopAppBar(navigateBack: () -> Unit, modifier: Modifier = Modif
     )
 }
 
-@Preview
+@Preview(name = "Podcast details header")
 @Composable
 @PreviewLightDark
 fun PodcastDetailsHeaderItemPreview() {

--- a/Jetcaster/mobile/src/main/java/com/example/jetcaster/ui/shared/EpisodeListItem.kt
+++ b/Jetcaster/mobile/src/main/java/com/example/jetcaster/ui/shared/EpisodeListItem.kt
@@ -287,16 +287,7 @@ private fun EpisodeListItemImage(podcast: PodcastInfo, modifier: Modifier = Modi
     )
 }
 
-@Preview(
-    name = "Light Mode",
-    showBackground = true,
-    uiMode = Configuration.UI_MODE_NIGHT_NO,
-)
-@Preview(
-    name = "Dark Mode",
-    showBackground = true,
-    uiMode = Configuration.UI_MODE_NIGHT_YES,
-)
+@Preview(name = "Episode list item", showBackground = true)
 @Composable
 @PreviewLightDark
 private fun EpisodeListItemPreview() {

--- a/Jetchat/app/src/main/java/com/example/compose/jetchat/components/JetchatAppBar.kt
+++ b/Jetchat/app/src/main/java/com/example/compose/jetchat/components/JetchatAppBar.kt
@@ -62,7 +62,7 @@ fun JetchatAppBar(
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
-@Preview
+@Preview(name = "App bar")
 @Composable
 @PreviewLightDark
 fun JetchatAppBarPreview() {

--- a/Jetchat/app/src/main/java/com/example/compose/jetchat/components/JetchatDrawer.kt
+++ b/Jetchat/app/src/main/java/com/example/compose/jetchat/components/JetchatDrawer.kt
@@ -219,7 +219,7 @@ fun DividerItem(modifier: Modifier = Modifier) {
 }
 
 @Composable
-@Preview
+@Preview(name = "Drawer")
 @PreviewLightDark
 fun DrawerPreview() {
     JetchatTheme {

--- a/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/Conversation.kt
+++ b/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/Conversation.kt
@@ -547,7 +547,7 @@ fun ConversationPreview() {
     }
 }
 
-@Preview
+@Preview(name = "Channel bar")
 @Composable
 @PreviewLightDark
 fun ChannelBarPrev() {
@@ -556,7 +556,7 @@ fun ChannelBarPrev() {
     }
 }
 
-@Preview
+@Preview(name = "Day header")
 @Composable
 @PreviewLightDark
 fun DayHeaderPrev() {

--- a/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/UserInput.kt
+++ b/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/UserInput.kt
@@ -126,7 +126,7 @@ enum class EmojiStickerSelector {
     STICKER,
 }
 
-@Preview
+@Preview(name = "User input")
 @Composable
 @PreviewLightDark
 fun UserInputPreview() {

--- a/Jetchat/app/src/main/java/com/example/compose/jetchat/profile/Profile.kt
+++ b/Jetchat/app/src/main/java/com/example/compose/jetchat/profile/Profile.kt
@@ -286,7 +286,7 @@ fun ConvPreviewPortraitOtherDefault() {
     }
 }
 
-@Preview
+@Preview(name = "Profile FAB")
 @Composable
 @PreviewLightDark
 fun ProfileFabPreview() {

--- a/Jetchat/catalog.spec.json
+++ b/Jetchat/catalog.spec.json
@@ -45,11 +45,6 @@
           "caption": "Conversation screen — message list, input bar and app bar together.",
           "variants": [
             {
-              "preview": "JetchatConversationContentDarkPreview",
-              "caption": "Conversation screen, dark theme.",
-              "theme": "dark"
-            },
-            {
               "preview": "JetchatConversationContentMediumPreview",
               "caption": "Conversation screen at the 700dp medium breakpoint.",
               "props": {
@@ -72,26 +67,12 @@
         {
           "componentId": "Conversation/Day header",
           "preview": "DayHeaderPrev",
-          "caption": "Date separator between message groups.",
-          "variants": [
-            {
-              "preview": "JetchatDayHeaderDarkPreview",
-              "caption": "Date separator, dark theme.",
-              "theme": "dark"
-            }
-          ]
+          "caption": "Date separator between message groups."
         },
         {
           "componentId": "Conversation/Jump to bottom",
           "preview": "JetchatJumpToBottomLightPreview",
-          "caption": "Jump-to-bottom affordance that appears when scrolled away from the latest message.",
-          "variants": [
-            {
-              "preview": "JetchatJumpToBottomDarkPreview",
-              "caption": "Jump-to-bottom pill, dark theme.",
-              "theme": "dark"
-            }
-          ]
+          "caption": "Jump-to-bottom affordance that appears when scrolled away from the latest message."
         }
       ]
     },
@@ -139,11 +120,6 @@
               "props": {
                 "content": "long text + link"
               }
-            },
-            {
-              "preview": "JetchatMessageOtherDarkPreview",
-              "caption": "Other author's message, dark theme.",
-              "theme": "dark"
             },
             {
               "preview": "JetchatMessageMeDarkPreview",
@@ -208,14 +184,7 @@
         {
           "componentId": "Messages/List",
           "preview": "JetchatMessagesPreview",
-          "caption": "The full message list with author grouping and day headers.",
-          "variants": [
-            {
-              "preview": "JetchatMessagesDarkPreview",
-              "caption": "Message list, dark theme.",
-              "theme": "dark"
-            }
-          ]
+          "caption": "The full message list with author grouping and day headers."
         }
       ]
     },
@@ -226,14 +195,7 @@
         {
           "componentId": "Conversation/Input",
           "preview": "UserInputPreview",
-          "caption": "Message composer with its emoji/attachment selectors.",
-          "variants": [
-            {
-              "preview": "JetchatUserInputDarkPreview",
-              "caption": "Composer, dark theme.",
-              "theme": "dark"
-            }
-          ]
+          "caption": "Message composer with its emoji/attachment selectors."
         },
         {
           "componentId": "Composer/Emoji selector",
@@ -462,25 +424,13 @@
         {
           "componentId": "Chrome/App bar",
           "preview": "JetchatAppBarPreview",
-          "caption": "Jetchat app bar.",
-          "variants": [
-            {
-              "preview": "JetchatAppBarPreviewDark",
-              "caption": "App bar, dark theme.",
-              "theme": "dark"
-            }
-          ]
+          "caption": "Jetchat app bar."
         },
         {
           "componentId": "Chrome/Drawer",
           "preview": "DrawerPreview",
           "caption": "Navigation drawer listing channels and direct messages.",
           "variants": [
-            {
-              "preview": "DrawerPreviewDark",
-              "caption": "Drawer, dark theme.",
-              "theme": "dark"
-            },
             {
               "preview": "JetchatDrawerContentChatSelectedPreview",
               "caption": "Selection moved to the second chat row.",
@@ -516,11 +466,6 @@
           "preview": "ChannelBarPrev",
           "caption": "Channel name bar.",
           "variants": [
-            {
-              "preview": "JetchatChannelNameBarDarkPreview",
-              "caption": "Channel bar, dark theme.",
-              "theme": "dark"
-            },
             {
               "preview": "JetchatChannelNameBarLongNamePreview",
               "caption": "A channel name long enough to test truncation.",

--- a/Jetsnack/app/src/debug/java/com/example/jetsnack/catalog/JetsnackComponentPreviews.kt
+++ b/Jetsnack/app/src/debug/java/com/example/jetsnack/catalog/JetsnackComponentPreviews.kt
@@ -122,7 +122,6 @@ private fun Wrap(content: @Composable () -> Unit) = JetsnackPreviewWrapper {
 // ------------------------------------------------------------------ surface
 
 @Preview("default")
-@Preview("dark theme", uiMode = UI_MODE_NIGHT_YES)
 @Composable
 @PreviewLightDark
 fun JetsnackSurfaceFlatPreview() = Wrap {
@@ -196,7 +195,6 @@ private class PreviewSnackbarData(override val visuals: SnackbarVisuals) : Snack
 }
 
 @Preview("default")
-@Preview("dark theme", uiMode = UI_MODE_NIGHT_YES)
 @Composable
 @PreviewLightDark
 fun JetsnackSnackbarPreview() = Wrap {
@@ -247,7 +245,6 @@ fun VerticalGridThreeColumnPreview() = Wrap {
 // ------------------------------------------------------------------ snack surfaces
 
 @Preview("default")
-@Preview("dark theme", uiMode = UI_MODE_NIGHT_YES)
 @Composable
 @PreviewLightDark
 fun SnackItemPreview() = Wrap {
@@ -267,7 +264,6 @@ fun SnackImagePreview() = Wrap {
 }
 
 @Preview("default", heightDp = 320)
-@Preview("dark theme", uiMode = UI_MODE_NIGHT_YES, heightDp = 320)
 @Composable
 @PreviewLightDark
 fun SnackCollectionHighlightPreview() = Wrap {
@@ -291,7 +287,6 @@ fun SnackCollectionNormalPreview() = Wrap {
 // ------------------------------------------------------------------ filter bar
 
 @Preview("default")
-@Preview("dark theme", uiMode = UI_MODE_NIGHT_YES)
 @Composable
 @PreviewLightDark
 fun FilterBarPreview() = Wrap {
@@ -340,7 +335,6 @@ private fun previewFilters() = listOf(
 // ------------------------------------------------------------------ cart rows
 
 @Preview("default")
-@Preview("dark theme", uiMode = UI_MODE_NIGHT_YES)
 @Composable
 @PreviewLightDark
 fun CartItemPreview() = Wrap {
@@ -378,7 +372,6 @@ fun CartItemManyPreview() = Wrap {
 }
 
 @Preview("default")
-@Preview("dark theme", uiMode = UI_MODE_NIGHT_YES)
 @Composable
 @PreviewLightDark
 fun SummaryItemPreview() = Wrap {
@@ -477,7 +470,6 @@ fun SearchBarDarkCatalogPreview() = SearchBarCatalogPreview()
 fun SearchBarLargeFontCatalogPreview() = SearchBarCatalogPreview()
 
 @Preview("default")
-@Preview("dark theme", uiMode = UI_MODE_NIGHT_YES)
 @Preview("large font", fontScale = 2f, widthDp = 412, heightDp = 220)
 @Composable
 @PreviewLightDark
@@ -517,7 +509,6 @@ fun SearchSuggestionsDarkPreview() = SearchSuggestionsPreview()
 fun SearchSuggestionsLargeFontPreview() = SearchSuggestionsPreview()
 
 @Preview("default")
-@Preview("dark theme", uiMode = UI_MODE_NIGHT_YES)
 @Preview("large font", fontScale = 2f, widthDp = 412, heightDp = 220)
 @Composable
 @PreviewLightDark
@@ -547,7 +538,6 @@ fun SearchResultsPreview() = Wrap {
 }
 
 @Preview("default")
-@Preview("dark theme", uiMode = UI_MODE_NIGHT_YES)
 @Composable
 @PreviewLightDark
 fun NoResultsPreview() = Wrap {
@@ -595,7 +585,6 @@ private fun BottomBar(current: HomeSections) = Wrap {
 }
 
 @Preview("default")
-@Preview("dark theme", uiMode = UI_MODE_NIGHT_YES)
 @Composable
 @PreviewLightDark
 fun JetsnackBottomBarFeedPreview() = BottomBar(HomeSections.FEED)

--- a/Jetsnack/app/src/debug/java/com/example/jetsnack/catalog/JetsnackScreenPreviews.kt
+++ b/Jetsnack/app/src/debug/java/com/example/jetsnack/catalog/JetsnackScreenPreviews.kt
@@ -36,11 +36,6 @@ import com.example.jetsnack.ui.home.search.Search
 
 @Preview("default", device = "spec:width=400dp,height=800dp,dpi=160")
 @Preview(
-    "dark theme",
-    uiMode = UI_MODE_NIGHT_YES,
-    device = "spec:width=400dp,height=800dp,dpi=160",
-)
-@Preview(
     "large font",
     fontScale = 2f,
     device = "spec:width=700dp,height=800dp,dpi=160",
@@ -52,11 +47,6 @@ fun FeedScreenPreview() = JetsnackPreviewWrapper {
 }
 
 @Preview("default", device = "spec:width=400dp,height=800dp,dpi=160")
-@Preview(
-    "dark theme",
-    uiMode = UI_MODE_NIGHT_YES,
-    device = "spec:width=400dp,height=800dp,dpi=160",
-)
 @Preview(
     "large font",
     fontScale = 2f,
@@ -89,7 +79,6 @@ fun CartScreenEmptyPreview() = JetsnackPreviewWrapper {
 }
 
 @Preview("default")
-@Preview("dark theme", uiMode = UI_MODE_NIGHT_YES)
 @Preview("large font", fontScale = 2f, widthDp = 412, heightDp = 800)
 @Composable
 @PreviewLightDark
@@ -98,11 +87,6 @@ fun ProfileScreenPreview() = JetsnackPreviewWrapper {
 }
 
 @Preview("search", device = "spec:width=400dp,height=800dp,dpi=160")
-@Preview(
-    "search dark",
-    uiMode = UI_MODE_NIGHT_YES,
-    device = "spec:width=400dp,height=800dp,dpi=160",
-)
 @Composable
 @PreviewLightDark
 fun SearchScreenPreview() = JetsnackPreviewWrapper {

--- a/Jetsnack/app/src/main/java/com/example/jetsnack/ui/components/Button.kt
+++ b/Jetsnack/app/src/main/java/com/example/jetsnack/ui/components/Button.kt
@@ -105,7 +105,6 @@ fun JetsnackButton(
 private val ButtonShape = RoundedCornerShape(percent = 50)
 
 @Preview("default", "round")
-@Preview("dark theme", "round", uiMode = UI_MODE_NIGHT_YES)
 @Preview("large font", "round", fontScale = 2f, widthDp = 412, heightDp = 120)
 @Composable
 @PreviewLightDark

--- a/Jetsnack/app/src/main/java/com/example/jetsnack/ui/components/Card.kt
+++ b/Jetsnack/app/src/main/java/com/example/jetsnack/ui/components/Card.kt
@@ -53,7 +53,6 @@ fun JetsnackCard(
 }
 
 @Preview("default")
-@Preview("dark theme", uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Preview("large font", fontScale = 2f, widthDp = 412, heightDp = 180)
 @Composable
 @PreviewLightDark

--- a/Jetsnack/app/src/main/java/com/example/jetsnack/ui/components/Divider.kt
+++ b/Jetsnack/app/src/main/java/com/example/jetsnack/ui/components/Divider.kt
@@ -46,7 +46,6 @@ fun JetsnackDivider(
 private const val DividerAlpha = 0.12f
 
 @Preview("default", showBackground = true)
-@Preview("dark theme", uiMode = Configuration.UI_MODE_NIGHT_YES, showBackground = true)
 @Composable
 @PreviewLightDark
 private fun DividerPreview() {

--- a/Jetsnack/app/src/main/java/com/example/jetsnack/ui/components/Filters.kt
+++ b/Jetsnack/app/src/main/java/com/example/jetsnack/ui/components/Filters.kt
@@ -172,7 +172,6 @@ private fun FilterDisabledPreview() {
 }
 
 @Preview("default")
-@Preview("dark theme", uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Preview("large font", fontScale = 2f, widthDp = 412, heightDp = 120)
 @Composable
 @PreviewLightDark

--- a/Jetsnack/app/src/main/java/com/example/jetsnack/ui/components/GradientTintedIconButton.kt
+++ b/Jetsnack/app/src/main/java/com/example/jetsnack/ui/components/GradientTintedIconButton.kt
@@ -97,7 +97,6 @@ fun JetsnackGradientTintedIconButton(
 }
 
 @Preview("default")
-@Preview("dark theme", uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 @PreviewLightDark
 private fun GradientTintedIconButtonPreview() {

--- a/Jetsnack/app/src/main/java/com/example/jetsnack/ui/components/QuantitySelector.kt
+++ b/Jetsnack/app/src/main/java/com/example/jetsnack/ui/components/QuantitySelector.kt
@@ -81,7 +81,6 @@ fun QuantitySelector(count: Int, decreaseItemCount: () -> Unit, increaseItemCoun
 }
 
 @Preview("default")
-@Preview("dark theme", uiMode = UI_MODE_NIGHT_YES)
 @Preview("large font", fontScale = 2f, widthDp = 412, heightDp = 120)
 @Composable
 @PreviewLightDark

--- a/Jetsnack/app/src/main/java/com/example/jetsnack/ui/components/Snacks.kt
+++ b/Jetsnack/app/src/main/java/com/example/jetsnack/ui/components/Snacks.kt
@@ -475,7 +475,6 @@ fun SnackImage(
 }
 
 @Preview("default")
-@Preview("dark theme", uiMode = UI_MODE_NIGHT_YES)
 @Preview("large font", fontScale = 2f, widthDp = 412, heightDp = 300)
 @Composable
 @PreviewLightDark

--- a/Jetsnack/app/src/main/java/com/example/jetsnack/ui/home/DestinationBar.kt
+++ b/Jetsnack/app/src/main/java/com/example/jetsnack/ui/home/DestinationBar.kt
@@ -108,7 +108,6 @@ fun DestinationBar(modifier: Modifier = Modifier) {
 }
 
 @Preview("default")
-@Preview("dark theme", uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Preview("large font", fontScale = 2f, widthDp = 412, heightDp = 160)
 @Composable
 @PreviewLightDark

--- a/Jetsnack/catalog.spec.json
+++ b/Jetsnack/catalog.spec.json
@@ -105,26 +105,12 @@
         {
           "componentId": "Tokens/Colour",
           "preview": "JetsnackColorTokensLightPreview",
-          "caption": "The JetsnackColors palette as the app models it — brand, ui, text and icon roles, not M3 roles.",
-          "variants": [
-            {
-              "preview": "JetsnackColorTokensDarkPreview",
-              "caption": "Dark palette. Note it is not a mechanical inversion: textPrimary and iconPrimary switch from the brand purple to Shadow1.",
-              "theme": "dark"
-            }
-          ]
+          "caption": "The JetsnackColors palette as the app models it — brand, ui, text and icon roles, not M3 roles."
         },
         {
           "componentId": "Tokens/Gradients",
           "preview": "JetsnackGradientTokensPreview",
-          "caption": "The seven gradient ramps plus tornado1. These are the signature of the system and have no Material 3 equivalent, so they appear nowhere in the @ThemeCatalog specimen sheets.",
-          "variants": [
-            {
-              "preview": "JetsnackGradientTokensDarkPreview",
-              "caption": "Dark ramps.",
-              "theme": "dark"
-            }
-          ]
+          "caption": "The seven gradient ramps plus tornado1. These are the signature of the system and have no Material 3 equivalent, so they appear nowhere in the @ThemeCatalog specimen sheets."
         }
       ]
     },
@@ -301,11 +287,6 @@
               "state": "searching"
             },
             {
-              "preview": "SearchBarDarkCatalogPreview",
-              "caption": "Search entry field in dark mode.",
-              "theme": "dark"
-            },
-            {
               "preview": "SearchBarLargeFontCatalogPreview",
               "caption": "Search entry field at 2× font scale.",
               "props": {
@@ -352,11 +333,6 @@
           "preview": "SearchSuggestionsPreview",
           "caption": "Suggestion list shown before a query is entered, driven by SearchRepo.getSuggestions().",
           "variants": [
-            {
-              "preview": "SearchSuggestionsDarkPreview",
-              "caption": "Suggestion list in dark mode.",
-              "theme": "dark"
-            },
             {
               "preview": "SearchSuggestionsLargeFontPreview",
               "caption": "Suggestion list at 2× font scale.",
@@ -477,11 +453,6 @@
           "preview": "SnackDetailCatalogPreview",
           "caption": "Product detail — the collapsing-header screen that anchors the shared-element transition.",
           "variants": [
-            {
-              "preview": "SnackDetailDarkCatalogPreview",
-              "caption": "Product detail in dark mode.",
-              "theme": "dark"
-            },
             {
               "preview": "SnackDetailLargeFontCatalogPreview",
               "caption": "Product detail at 2× font scale.",


### PR DESCRIPTION
## What changed

- replace redundant standalone Light/Dark `@Preview` annotations with one neutral catalog-discovery preview plus `@PreviewLightDark`
- keep size, font-scale, and state previews intact
- remove Jetchat and Jetsnack catalog-spec dark variants that duplicate the multipreview-generated dark axis

## Root cause

The Light/Dark coverage change stacked `@PreviewLightDark` on top of existing explicit dark previews. The catalog generator correctly rejected those inputs because two renders mapped to the same output axes. Some catalog specs also retained explicit dark variants after their base preview began producing both themes.

## Validation

- `compileDebugKotlin` passed for JetNews, Jetcaster mobile, Jetchat, and Jetsnack
- `spotlessCheck` passed in all four projects
- all four catalog specs passed `validate-catalog-spec.mjs`
- all four bundles passed `generate-design-catalog.mjs` with compose-preview 0.19.31 and no duplicate-axis errors
- generated catalogs contain 97 Light/Dark component pairs, all with distinct image hashes:
  - JetNews: 15/15
  - Jetcaster: 24/24
  - Jetchat: 24/24
  - Jetsnack: 34/34

Fixes the compose-samples portion of yschimke/compose-ai-tools#3267.