### PR TITLE
chore(deps): update compose-ai-tools to 0.19.38

### DIFF
--- a/JetLagged/gradle/libs.versions.toml
+++ b/JetLagged/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-composeAiPreview = "0.19.34"
+composeAiPreview = "0.19.38"
 accompanist = "0.37.3"
 android-material3 = "1.14.0"
 androidGradlePlugin = "9.2.1"

--- a/JetNews/gradle/libs.versions.toml
+++ b/JetNews/gradle/libs.versions.toml
@@ -4,7 +4,7 @@
 #####
 [versions]
 accompanist = "0.37.3"
-composeAiPreview = "0.19.34"
+composeAiPreview = "0.19.38"
 android-material3 = "1.14.0"
 androidGradlePlugin = "9.2.1"
 androidx-activity-compose = "1.13.0"

--- a/Jetcaster/gradle/libs.versions.toml
+++ b/Jetcaster/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 # Do not add a dependency to an individual sample, edit the global version instead.
 #####
 [versions]
-composeAiPreview = "0.19.34"
+composeAiPreview = "0.19.38"
 accompanist = "0.37.3"
 android-material3 = "1.14.0"
 androidGradlePlugin = "9.2.1"

--- a/Jetchat/gradle/libs.versions.toml
+++ b/Jetchat/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 # Do not add a dependency to an individual sample, edit the global version instead.
 #####
 [versions]
-composeAiPreview = "0.19.34"
+composeAiPreview = "0.19.38"
 accompanist = "0.37.3"
 android-material3 = "1.14.0"
 androidGradlePlugin = "9.2.1"

--- a/Jetsnack/gradle/libs.versions.toml
+++ b/Jetsnack/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-composeAiPreview = "0.19.34"
+composeAiPreview = "0.19.38"
 accompanist = "0.37.3"
 android-material3 = "1.14.0"
 androidGradlePlugin = "9.2.1"

--- a/Reply/gradle/libs.versions.toml
+++ b/Reply/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 # Do not add a dependency to an individual sample, edit the global version instead.
 #####
 [versions]
-composeAiPreview = "0.19.34"
+composeAiPreview = "0.19.38"
 accompanist = "0.37.3"
 android-material3 = "1.14.0"
 androidGradlePlugin = "9.2.1"


### PR DESCRIPTION
## Summary

Bumps the `composeAiPreview` version catalog pin from `0.19.34` to `0.19.38` in all six samples (Jetsnack, Reply, Jetcaster, Jetchat, JetLagged, JetNews). The pin drives both `ee.schimke.composeai:preview-annotations` and the `ee.schimke.composeai.preview` Gradle plugin.

[v0.19.38 release notes](https://github.com/yschimke/compose-ai-tools/releases/tag/v0.19.38) — the relevant fix for this repo is **gradle-plugin: pack desktop classes, not the android compilation** (compose-ai-tools#3356).

## Testing

- Verified `ee.schimke.composeai:preview-annotations:0.19.38` and the `ee.schimke.composeai.preview` plugin marker are published on Maven Central.
- No source changes; the design-artifacts / compose-preview CI on this branch exercises the render path.

No visual evidence: this is a renderer version pin with no Compose source changes. Any render differences will show up in the preview-diff comparison CI runs on this branch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LVTPbkUHDTZYDYE6Wbp3dG)_