### PR TITLE
chore(deps): update compose-ai-tools to 0.19.45

### DIFF
--- a/JetLagged/gradle/libs.versions.toml
+++ b/JetLagged/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-composeAiPreview = "0.19.38"
+composeAiPreview = "0.19.45"
 accompanist = "0.37.3"
 android-material3 = "1.14.0"
 androidGradlePlugin = "9.2.1"

--- a/JetNews/gradle/libs.versions.toml
+++ b/JetNews/gradle/libs.versions.toml
@@ -4,7 +4,7 @@
 #####
 [versions]
 accompanist = "0.37.3"
-composeAiPreview = "0.19.38"
+composeAiPreview = "0.19.45"
 android-material3 = "1.14.0"
 androidGradlePlugin = "9.2.1"
 androidx-activity-compose = "1.13.0"

--- a/Jetcaster/gradle/libs.versions.toml
+++ b/Jetcaster/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 # Do not add a dependency to an individual sample, edit the global version instead.
 #####
 [versions]
-composeAiPreview = "0.19.38"
+composeAiPreview = "0.19.45"
 accompanist = "0.37.3"
 android-material3 = "1.14.0"
 androidGradlePlugin = "9.2.1"

--- a/Jetchat/gradle/libs.versions.toml
+++ b/Jetchat/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 # Do not add a dependency to an individual sample, edit the global version instead.
 #####
 [versions]
-composeAiPreview = "0.19.38"
+composeAiPreview = "0.19.45"
 accompanist = "0.37.3"
 android-material3 = "1.14.0"
 androidGradlePlugin = "9.2.1"

--- a/Jetsnack/gradle/libs.versions.toml
+++ b/Jetsnack/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-composeAiPreview = "0.19.38"
+composeAiPreview = "0.19.45"
 accompanist = "0.37.3"
 android-material3 = "1.14.0"
 androidGradlePlugin = "9.2.1"

--- a/Reply/gradle/libs.versions.toml
+++ b/Reply/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 # Do not add a dependency to an individual sample, edit the global version instead.
 #####
 [versions]
-composeAiPreview = "0.19.38"
+composeAiPreview = "0.19.45"
 accompanist = "0.37.3"
 android-material3 = "1.14.0"
 androidGradlePlugin = "9.2.1"


### PR DESCRIPTION
## Summary

Bumps the compose-ai-tools pin from `0.19.38` to `0.19.45` across all six sample catalogs:

`Jetsnack`, `Reply`, `Jetcaster`, `Jetchat`, `JetLagged`, `JetNews` — each `gradle/libs.versions.toml` sets `composeAiPreview = "0.19.45"`, which drives both `ee.schimke.composeai:preview-annotations` and the `ee.schimke.composeai.preview` plugin.

No workflow refs change here: `.github/workflows/design-artifacts.yml` already tracks `compose-ai-tools@main` for the reusable pipeline and the CLI checkout, so the catalog pins were the only version left behind.

## Visual evidence

Renderer-version bump only — no sample's composables, themes, or previews changed, so there is no source-level before/after to picture. Any pixel drift comes from the renderer and is captured by the visual-diff bot on this PR (base render vs head render) across the sample catalogs.

## Test plan

- Per-sample preview renders run against 0.19.45.
- `design-artifacts` regenerates the delivery branches after merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WFqEqb1QaTbL542XYjJYvf)_