### PR TITLE
chore(deps): update compose-ai-tools to 0.19.46

### DIFF
--- a/JetLagged/gradle/libs.versions.toml
+++ b/JetLagged/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-composeAiPreview = "0.19.45"
+composeAiPreview = "0.19.46"
 accompanist = "0.37.3"
 android-material3 = "1.14.0"
 androidGradlePlugin = "9.2.1"

--- a/JetNews/gradle/libs.versions.toml
+++ b/JetNews/gradle/libs.versions.toml
@@ -4,7 +4,7 @@
 #####
 [versions]
 accompanist = "0.37.3"
-composeAiPreview = "0.19.45"
+composeAiPreview = "0.19.46"
 android-material3 = "1.14.0"
 androidGradlePlugin = "9.2.1"
 androidx-activity-compose = "1.13.0"

--- a/Jetcaster/gradle/libs.versions.toml
+++ b/Jetcaster/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 # Do not add a dependency to an individual sample, edit the global version instead.
 #####
 [versions]
-composeAiPreview = "0.19.45"
+composeAiPreview = "0.19.46"
 accompanist = "0.37.3"
 android-material3 = "1.14.0"
 androidGradlePlugin = "9.2.1"

--- a/Jetchat/gradle/libs.versions.toml
+++ b/Jetchat/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 # Do not add a dependency to an individual sample, edit the global version instead.
 #####
 [versions]
-composeAiPreview = "0.19.45"
+composeAiPreview = "0.19.46"
 accompanist = "0.37.3"
 android-material3 = "1.14.0"
 androidGradlePlugin = "9.2.1"

--- a/Jetsnack/gradle/libs.versions.toml
+++ b/Jetsnack/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-composeAiPreview = "0.19.45"
+composeAiPreview = "0.19.46"
 accompanist = "0.37.3"
 android-material3 = "1.14.0"
 androidGradlePlugin = "9.2.1"

--- a/Reply/gradle/libs.versions.toml
+++ b/Reply/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 # Do not add a dependency to an individual sample, edit the global version instead.
 #####
 [versions]
-composeAiPreview = "0.19.45"
+composeAiPreview = "0.19.46"
 accompanist = "0.37.3"
 android-material3 = "1.14.0"
 androidGradlePlugin = "9.2.1"


### PR DESCRIPTION
## Summary

Bumps the compose-ai-tools pin from `0.19.45` to `0.19.46` across all six sample catalogs (`Jetsnack`, `Reply`, `Jetcaster`, `Jetchat`, `JetLagged`, `JetNews`).

0.19.46 carries the render-graph fix from [compose-ai-tools#3483](https://github.com/yschimke/compose-ai-tools/pull/3483). 0.19.45 introduced a configuration-wide `configuration.exclude(group = "org.jetbrains.compose.*")` on the Android render graph; because that configuration `extendsFrom` the consumer's unit-test classpath, it stripped the **consumer's own** Compose Multiplatform dependencies, not just the renderer's transitives. The exclusion is now scoped to the dependencies the plugin itself contributes.

## Visual evidence

Renderer-version bump only — no sample's composables, themes, or previews changed, so there is no source-level before/after to picture. Any pixel drift comes from the renderer and is captured by the visual-diff bot on this PR.

## Test plan

- Per-sample preview renders run against 0.19.46. The render counts are the point of this PR: 0.19.45 silently dropped previews under `missing-renders policy=warn`, so a green check alone is not sufficient — the diff bot's rendered/failed counts are the evidence.
- `design-artifacts` regenerates the delivery branches after merge, replacing output produced by the broken renderer.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WFqEqb1QaTbL542XYjJYvf)_