### PR TITLE
chore(deps): bump compose-ai-tools to 0.19.51

### DIFF
--- a/JetLagged/gradle/libs.versions.toml
+++ b/JetLagged/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-composeAiPreview = "0.19.46"
+composeAiPreview = "0.19.51"
 accompanist = "0.37.3"
 android-material3 = "1.14.0"
 androidGradlePlugin = "9.2.1"

--- a/JetNews/gradle/libs.versions.toml
+++ b/JetNews/gradle/libs.versions.toml
@@ -4,7 +4,7 @@
 #####
 [versions]
 accompanist = "0.37.3"
-composeAiPreview = "0.19.46"
+composeAiPreview = "0.19.51"
 android-material3 = "1.14.0"
 androidGradlePlugin = "9.2.1"
 androidx-activity-compose = "1.13.0"

--- a/Jetcaster/gradle/libs.versions.toml
+++ b/Jetcaster/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 # Do not add a dependency to an individual sample, edit the global version instead.
 #####
 [versions]
-composeAiPreview = "0.19.46"
+composeAiPreview = "0.19.51"
 accompanist = "0.37.3"
 android-material3 = "1.14.0"
 androidGradlePlugin = "9.2.1"

--- a/Jetchat/gradle/libs.versions.toml
+++ b/Jetchat/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 # Do not add a dependency to an individual sample, edit the global version instead.
 #####
 [versions]
-composeAiPreview = "0.19.46"
+composeAiPreview = "0.19.51"
 accompanist = "0.37.3"
 android-material3 = "1.14.0"
 androidGradlePlugin = "9.2.1"

--- a/Jetsnack/gradle/libs.versions.toml
+++ b/Jetsnack/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-composeAiPreview = "0.19.46"
+composeAiPreview = "0.19.51"
 accompanist = "0.37.3"
 android-material3 = "1.14.0"
 androidGradlePlugin = "9.2.1"

--- a/Reply/gradle/libs.versions.toml
+++ b/Reply/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 # Do not add a dependency to an individual sample, edit the global version instead.
 #####
 [versions]
-composeAiPreview = "0.19.46"
+composeAiPreview = "0.19.51"
 accompanist = "0.37.3"
 android-material3 = "1.14.0"
 androidGradlePlugin = "9.2.1"


### PR DESCRIPTION
Bumps the `ee.schimke.composeai.preview` Gradle plugin and its `preview-annotations` artifact from **0.19.46 → 0.19.51** in all six sample projects: Jetsnack, Reply, Jetcaster, Jetchat, JetLagged, JetNews.

`.github/workflows/design-artifacts.yml` already tracks `compose-ai-tools/.github/workflows/design-artifacts-reusable.yml@main`, so there is no action pin to move here — the version catalogs were the only pinned surface.

### Checklist

- [x] Version-catalog only change; no source, no API surface, no docs to update.
- [x] Plugin and annotations move together (both resolve from the single `composeAiPreview` key in each project's catalog).
- [ ] CI renders the previews — the design-artifacts / compose-preview jobs are the real verification that 0.19.51's renderer produces the same output.

No UI code changed, so there is no before/after visual evidence to embed; any render drift this bump causes will show up in the CI preview-diff comment.

---
_Generated by [Claude Code](https://claude.ai/code/session_01141C3L3ahTgzWxEvjWBF7U)_