### PR TITLE
Fix preview theme overrides

### DIFF
--- a/JetLagged/app/src/debug/java/com/example/jetlagged/catalog/JetLaggedThemeCatalogs.kt
+++ b/JetLagged/app/src/debug/java/com/example/jetlagged/catalog/JetLaggedThemeCatalogs.kt
@@ -19,6 +19,7 @@ package com.example.jetlagged.catalog
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.PreviewWrapperProvider
 import com.example.jetlagged.ui.theme.JetLaggedTheme
+import com.example.jetlagged.ui.theme.PreviewThemeOverride
 import ee.schimke.composeai.preview.ThemeCatalog
 
 /*
@@ -45,11 +46,15 @@ import ee.schimke.composeai.preview.ThemeCatalog
 @ThemeCatalog(name = "JetLagged · Light", group = "JetLagged")
 class JetLaggedLightThemeCatalog : PreviewWrapperProvider {
     @Composable
-    override fun Wrap(content: @Composable () -> Unit) = JetLaggedTheme(isDarkTheme = false, content = content)
+    override fun Wrap(content: @Composable () -> Unit) = PreviewThemeOverride(content) { themedContent ->
+        JetLaggedTheme(isDarkTheme = false, content = themedContent)
+    }
 }
 
 @ThemeCatalog(name = "JetLagged · Dark", group = "JetLagged")
 class JetLaggedDarkThemeCatalog : PreviewWrapperProvider {
     @Composable
-    override fun Wrap(content: @Composable () -> Unit) = JetLaggedTheme(isDarkTheme = true, content = content)
+    override fun Wrap(content: @Composable () -> Unit) = PreviewThemeOverride(content) { themedContent ->
+        JetLaggedTheme(isDarkTheme = true, content = themedContent)
+    }
 }

--- a/JetLagged/app/src/main/java/com/example/jetlagged/ui/theme/PreviewTheme.kt
+++ b/JetLagged/app/src/main/java/com/example/jetlagged/ui/theme/PreviewTheme.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.jetlagged.ui.theme
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.staticCompositionLocalOf
+
+private val LocalPreviewThemeOverride = staticCompositionLocalOf { false }
+
+/** Applies the app theme unless an outer preview catalog has already selected one. */
+@Composable
+internal fun PreviewTheme(content: @Composable () -> Unit, theme: @Composable (@Composable () -> Unit) -> Unit) {
+    if (LocalPreviewThemeOverride.current) content() else theme(content)
+}
+
+/** Applies a catalog theme and prevents nested app-theme calls from replacing it. */
+@Composable
+internal fun PreviewThemeOverride(content: @Composable () -> Unit, theme: @Composable (@Composable () -> Unit) -> Unit) {
+    theme {
+        CompositionLocalProvider(LocalPreviewThemeOverride provides true, content = content)
+    }
+}

--- a/JetLagged/app/src/main/java/com/example/jetlagged/ui/theme/Theme.kt
+++ b/JetLagged/app/src/main/java/com/example/jetlagged/ui/theme/Theme.kt
@@ -102,23 +102,25 @@ private val shapes: Shapes
     )
 @Composable
 fun JetLaggedTheme(isDarkTheme: Boolean = isSystemInDarkTheme(), content: @Composable () -> Unit) {
-    val colorScheme: ColorScheme
-    val extraColors: JetLaggedExtraColors
-    if (isDarkTheme) {
-        colorScheme = DarkColorScheme
-        extraColors = DarkExtraColors
-    } else {
-        colorScheme = LightColorScheme
-        extraColors = LightExtraColors
-    }
+    PreviewTheme(content) { themedContent ->
+        val colorScheme: ColorScheme
+        val extraColors: JetLaggedExtraColors
+        if (isDarkTheme) {
+            colorScheme = DarkColorScheme
+            extraColors = DarkExtraColors
+        } else {
+            colorScheme = LightColorScheme
+            extraColors = LightExtraColors
+        }
 
-    CompositionLocalProvider(LocalExtraColors provides extraColors) {
-        MaterialTheme(
-            colorScheme = colorScheme,
-            typography = Typography,
-            shapes = shapes,
-            content = content,
-        )
+        CompositionLocalProvider(LocalExtraColors provides extraColors) {
+            MaterialTheme(
+                colorScheme = colorScheme,
+                typography = Typography,
+                shapes = shapes,
+                content = themedContent,
+            )
+        }
     }
 }
 

--- a/JetNews/app/src/debug/java/com/example/jetnews/catalog/JetnewsThemeCatalogs.kt
+++ b/JetNews/app/src/debug/java/com/example/jetnews/catalog/JetnewsThemeCatalogs.kt
@@ -24,6 +24,7 @@ import com.example.jetnews.ui.theme.DarkColors
 import com.example.jetnews.ui.theme.JetnewsShapes
 import com.example.jetnews.ui.theme.JetnewsTypography
 import com.example.jetnews.ui.theme.LightColors
+import com.example.jetnews.ui.theme.PreviewThemeOverride
 import ee.schimke.composeai.preview.ThemeCatalog
 
 /**
@@ -45,8 +46,9 @@ import ee.schimke.composeai.preview.ThemeCatalog
  * colour branch the catalog is trying to enumerate around.
  */
 @Composable
-private fun JetnewsScheme(scheme: ColorScheme, content: @Composable () -> Unit) =
-    MaterialTheme(colorScheme = scheme, shapes = JetnewsShapes, typography = JetnewsTypography, content = content)
+private fun JetnewsScheme(scheme: ColorScheme, content: @Composable () -> Unit) = PreviewThemeOverride(content) { themedContent ->
+    MaterialTheme(colorScheme = scheme, shapes = JetnewsShapes, typography = JetnewsTypography, content = themedContent)
+}
 
 @ThemeCatalog(name = "JetNews · Light", group = "JetNews")
 class JetnewsLightThemeCatalog : PreviewWrapperProvider {

--- a/JetNews/app/src/main/java/com/example/jetnews/ui/theme/PreviewTheme.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/theme/PreviewTheme.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.jetnews.ui.theme
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.staticCompositionLocalOf
+
+private val LocalPreviewThemeOverride = staticCompositionLocalOf { false }
+
+/** Applies the app theme unless an outer preview catalog has already selected one. */
+@Composable
+internal fun PreviewTheme(content: @Composable () -> Unit, theme: @Composable (@Composable () -> Unit) -> Unit) {
+    if (LocalPreviewThemeOverride.current) content() else theme(content)
+}
+
+/** Applies a catalog theme and prevents nested app-theme calls from replacing it. */
+@Composable
+internal fun PreviewThemeOverride(content: @Composable () -> Unit, theme: @Composable (@Composable () -> Unit) -> Unit) {
+    theme {
+        CompositionLocalProvider(LocalPreviewThemeOverride provides true, content = content)
+    }
+}

--- a/JetNews/app/src/main/java/com/example/jetnews/ui/theme/Theme.kt
+++ b/JetNews/app/src/main/java/com/example/jetnews/ui/theme/Theme.kt
@@ -88,18 +88,20 @@ val DarkColors = darkColorScheme(
 
 @Composable
 fun JetnewsTheme(darkTheme: Boolean = isSystemInDarkTheme(), content: @Composable () -> Unit) {
-    val colorScheme =
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            val context = LocalContext.current
-            if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
-        } else {
-            if (darkTheme) DarkColors else LightColors
-        }
+    PreviewTheme(content) { themedContent ->
+        val colorScheme =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                val context = LocalContext.current
+                if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
+            } else {
+                if (darkTheme) DarkColors else LightColors
+            }
 
-    MaterialTheme(
-        colorScheme = colorScheme,
-        shapes = JetnewsShapes,
-        typography = JetnewsTypography,
-        content = content,
-    )
+        MaterialTheme(
+            colorScheme = colorScheme,
+            shapes = JetnewsShapes,
+            typography = JetnewsTypography,
+            content = themedContent,
+        )
+    }
 }

--- a/Jetcaster/mobile/src/debug/java/com/example/jetcaster/catalog/JetcasterThemeCatalogs.kt
+++ b/Jetcaster/mobile/src/debug/java/com/example/jetcaster/catalog/JetcasterThemeCatalogs.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.PreviewWrapperProvider
 import com.example.jetcaster.designsystem.theme.JetcasterShapes
 import com.example.jetcaster.designsystem.theme.JetcasterTypography
+import com.example.jetcaster.ui.theme.PreviewThemeOverride
 import com.example.jetcaster.ui.theme.darkScheme
 import com.example.jetcaster.ui.theme.highContrastDarkColorScheme
 import com.example.jetcaster.ui.theme.highContrastLightColorScheme
@@ -54,13 +55,15 @@ import ee.schimke.composeai.preview.ThemeCatalog
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
-private fun JetcasterScheme(scheme: ColorScheme, content: @Composable () -> Unit) = MaterialExpressiveTheme(
-    colorScheme = scheme,
-    motionScheme = MotionScheme.expressive(),
-    shapes = JetcasterShapes,
-    typography = JetcasterTypography,
-    content = content,
-)
+private fun JetcasterScheme(scheme: ColorScheme, content: @Composable () -> Unit) = PreviewThemeOverride(content) { themedContent ->
+    MaterialExpressiveTheme(
+        colorScheme = scheme,
+        motionScheme = MotionScheme.expressive(),
+        shapes = JetcasterShapes,
+        typography = JetcasterTypography,
+        content = themedContent,
+    )
+}
 
 /** The scheme the app actually ships with — every other catalog here is currently unreachable. */
 @ThemeCatalog(name = "Jetcaster · Dark", group = "Jetcaster")

--- a/Jetcaster/mobile/src/main/java/com/example/jetcaster/ui/theme/PreviewTheme.kt
+++ b/Jetcaster/mobile/src/main/java/com/example/jetcaster/ui/theme/PreviewTheme.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.jetcaster.ui.theme
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.staticCompositionLocalOf
+
+private val LocalPreviewThemeOverride = staticCompositionLocalOf { false }
+
+/** Applies the app theme unless an outer preview catalog has already selected one. */
+@Composable
+internal fun PreviewTheme(content: @Composable () -> Unit, theme: @Composable (@Composable () -> Unit) -> Unit) {
+    if (LocalPreviewThemeOverride.current) content() else theme(content)
+}
+
+/** Applies a catalog theme and prevents nested app-theme calls from replacing it. */
+@Composable
+internal fun PreviewThemeOverride(content: @Composable () -> Unit, theme: @Composable (@Composable () -> Unit) -> Unit) {
+    theme {
+        CompositionLocalProvider(LocalPreviewThemeOverride provides true, content = content)
+    }
+}

--- a/Jetcaster/mobile/src/main/java/com/example/jetcaster/ui/theme/Theme.kt
+++ b/Jetcaster/mobile/src/main/java/com/example/jetcaster/ui/theme/Theme.kt
@@ -479,22 +479,24 @@ internal val highContrastDarkColorScheme = darkColorScheme(
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun JetcasterTheme(darkTheme: Boolean = isSystemInDarkTheme(), dynamicColor: Boolean = false, content: @Composable () -> Unit) {
-    val colorScheme = when {
-        dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
-            val context = LocalContext.current
-            if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
+    PreviewTheme(content) { themedContent ->
+        val colorScheme = when {
+            dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
+                val context = LocalContext.current
+                if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
+            }
+
+            darkTheme -> darkScheme
+
+            else -> lightScheme
         }
 
-        darkTheme -> darkScheme
-
-        else -> lightScheme
+        MaterialExpressiveTheme(
+            colorScheme = colorScheme,
+            motionScheme = MotionScheme.expressive(),
+            shapes = JetcasterShapes,
+            typography = JetcasterTypography,
+            content = themedContent,
+        )
     }
-
-    MaterialExpressiveTheme(
-        colorScheme = colorScheme,
-        motionScheme = MotionScheme.expressive(),
-        shapes = JetcasterShapes,
-        typography = JetcasterTypography,
-        content = content,
-    )
 }

--- a/Jetcaster/wear/src/debug/java/com/example/jetcaster/catalog/JetcasterWearThemeCatalog.kt
+++ b/Jetcaster/wear/src/debug/java/com/example/jetcaster/catalog/JetcasterWearThemeCatalog.kt
@@ -18,6 +18,7 @@ package com.example.jetcaster.catalog
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.PreviewWrapperProvider
+import com.example.jetcaster.theme.PreviewThemeOverride
 import com.example.jetcaster.theme.WearAppTheme
 import ee.schimke.composeai.preview.WearThemeCatalog
 
@@ -30,5 +31,7 @@ import ee.schimke.composeai.preview.WearThemeCatalog
 @WearThemeCatalog(name = "Dark", group = "Jetcaster Wear")
 class JetcasterWearDarkThemeCatalog : PreviewWrapperProvider {
     @Composable
-    override fun Wrap(content: @Composable () -> Unit) = WearAppTheme(content)
+    override fun Wrap(content: @Composable () -> Unit) = PreviewThemeOverride(content) { themedContent ->
+        WearAppTheme(themedContent)
+    }
 }

--- a/Jetcaster/wear/src/main/java/com/example/jetcaster/theme/PreviewTheme.kt
+++ b/Jetcaster/wear/src/main/java/com/example/jetcaster/theme/PreviewTheme.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.jetcaster.theme
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.staticCompositionLocalOf
+
+private val LocalPreviewThemeOverride = staticCompositionLocalOf { false }
+
+/** Applies the app theme unless an outer preview catalog has already selected one. */
+@Composable
+internal fun PreviewTheme(content: @Composable () -> Unit, theme: @Composable (@Composable () -> Unit) -> Unit) {
+    if (LocalPreviewThemeOverride.current) content() else theme(content)
+}
+
+/** Applies a catalog theme and prevents nested app-theme calls from replacing it. */
+@Composable
+internal fun PreviewThemeOverride(content: @Composable () -> Unit, theme: @Composable (@Composable () -> Unit) -> Unit) {
+    theme {
+        CompositionLocalProvider(LocalPreviewThemeOverride provides true, content = content)
+    }
+}

--- a/Jetcaster/wear/src/main/java/com/example/jetcaster/theme/WearAppTheme.kt
+++ b/Jetcaster/wear/src/main/java/com/example/jetcaster/theme/WearAppTheme.kt
@@ -21,10 +21,12 @@ import androidx.wear.compose.material3.MaterialTheme
 
 @Composable
 fun WearAppTheme(content: @Composable () -> Unit) {
-    MaterialTheme(
-        colorScheme = wearColorPalette,
-        typography = Typography,
-        shapes = Shapes,
-        content = content,
-    )
+    PreviewTheme(content) { themedContent ->
+        MaterialTheme(
+            colorScheme = wearColorPalette,
+            typography = Typography,
+            shapes = Shapes,
+            content = themedContent,
+        )
+    }
 }

--- a/Jetchat/app/src/debug/java/com/example/compose/jetchat/catalog/JetchatThemeCatalogs.kt
+++ b/Jetchat/app/src/debug/java/com/example/compose/jetchat/catalog/JetchatThemeCatalogs.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.tooling.preview.PreviewWrapperProvider
 import com.example.compose.jetchat.theme.JetchatDarkColorScheme
 import com.example.compose.jetchat.theme.JetchatLightColorScheme
 import com.example.compose.jetchat.theme.JetchatTypography
+import com.example.compose.jetchat.theme.PreviewThemeOverride
 import ee.schimke.composeai.preview.ThemeCatalog
 
 /*
@@ -49,8 +50,9 @@ import ee.schimke.composeai.preview.ThemeCatalog
  */
 
 @Composable
-private fun JetchatScheme(scheme: ColorScheme, content: @Composable () -> Unit) =
-    MaterialTheme(colorScheme = scheme, typography = JetchatTypography, content = content)
+private fun JetchatScheme(scheme: ColorScheme, content: @Composable () -> Unit) = PreviewThemeOverride(content) { themedContent ->
+    MaterialTheme(colorScheme = scheme, typography = JetchatTypography, content = themedContent)
+}
 
 @ThemeCatalog(name = "Jetchat · Light", group = "Jetchat")
 class JetchatLightThemeCatalog : PreviewWrapperProvider {

--- a/Jetchat/app/src/main/java/com/example/compose/jetchat/theme/PreviewTheme.kt
+++ b/Jetchat/app/src/main/java/com/example/compose/jetchat/theme/PreviewTheme.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.compose.jetchat.theme
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.staticCompositionLocalOf
+
+private val LocalPreviewThemeOverride = staticCompositionLocalOf { false }
+
+/** Applies the app theme unless an outer preview catalog has already selected one. */
+@Composable
+internal fun PreviewTheme(content: @Composable () -> Unit, theme: @Composable (@Composable () -> Unit) -> Unit) {
+    if (LocalPreviewThemeOverride.current) content() else theme(content)
+}
+
+/** Applies a catalog theme and prevents nested app-theme calls from replacing it. */
+@Composable
+internal fun PreviewThemeOverride(content: @Composable () -> Unit, theme: @Composable (@Composable () -> Unit) -> Unit) {
+    theme {
+        CompositionLocalProvider(LocalPreviewThemeOverride provides true, content = content)
+    }
+}

--- a/Jetchat/app/src/main/java/com/example/compose/jetchat/theme/Themes.kt
+++ b/Jetchat/app/src/main/java/com/example/compose/jetchat/theme/Themes.kt
@@ -89,24 +89,26 @@ val JetchatLightColorScheme = lightColorScheme(
 @SuppressLint("NewApi")
 @Composable
 fun JetchatTheme(isDarkTheme: Boolean = isSystemInDarkTheme(), isDynamicColor: Boolean = true, content: @Composable () -> Unit) {
-    val dynamicColor = isDynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
-    val myColorScheme = when {
-        dynamicColor && isDarkTheme -> {
-            dynamicDarkColorScheme(LocalContext.current)
+    PreviewTheme(content) { themedContent ->
+        val dynamicColor = isDynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+        val myColorScheme = when {
+            dynamicColor && isDarkTheme -> {
+                dynamicDarkColorScheme(LocalContext.current)
+            }
+
+            dynamicColor && !isDarkTheme -> {
+                dynamicLightColorScheme(LocalContext.current)
+            }
+
+            isDarkTheme -> JetchatDarkColorScheme
+
+            else -> JetchatLightColorScheme
         }
 
-        dynamicColor && !isDarkTheme -> {
-            dynamicLightColorScheme(LocalContext.current)
-        }
-
-        isDarkTheme -> JetchatDarkColorScheme
-
-        else -> JetchatLightColorScheme
+        MaterialTheme(
+            colorScheme = myColorScheme,
+            typography = JetchatTypography,
+            content = themedContent,
+        )
     }
-
-    MaterialTheme(
-        colorScheme = myColorScheme,
-        typography = JetchatTypography,
-        content = content,
-    )
 }

--- a/Jetsnack/app/src/debug/java/com/example/jetsnack/catalog/JetsnackThemeCatalogs.kt
+++ b/Jetsnack/app/src/debug/java/com/example/jetsnack/catalog/JetsnackThemeCatalogs.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.tooling.preview.PreviewWrapperProvider
 import com.example.jetsnack.ui.theme.DarkColorPalette
 import com.example.jetsnack.ui.theme.JetsnackColors
 import com.example.jetsnack.ui.theme.LightColorPalette
+import com.example.jetsnack.ui.theme.PreviewThemeOverride
 import com.example.jetsnack.ui.theme.ProvideJetsnackColors
 import com.example.jetsnack.ui.theme.Shapes
 import com.example.jetsnack.ui.theme.Typography
@@ -53,49 +54,51 @@ import ee.schimke.composeai.preview.ThemeCatalog
  * sheets in `JetsnackComponentPreviews.kt`.
  */
 @Composable
-private fun JetsnackPalette(colors: JetsnackColors, content: @Composable () -> Unit) = ProvideJetsnackColors(colors) {
-    MaterialTheme(
-        colorScheme = if (colors.isDark) {
-            darkColorScheme(
-                primary = colors.brand,
-                onPrimary = colors.textInteractive,
-                secondary = colors.brandSecondary,
-                onSecondary = colors.textInteractive,
-                tertiary = colors.textLink,
-                background = colors.uiBackground,
-                onBackground = colors.textSecondary,
-                surface = colors.uiBackground,
-                onSurface = colors.textSecondary,
-                surfaceVariant = colors.uiFloated,
-                onSurfaceVariant = colors.textHelp,
-                surfaceTint = colors.brand,
-                outline = colors.uiBorder,
-                error = colors.error,
-                onError = colors.textInteractive,
-            )
-        } else {
-            lightColorScheme(
-                primary = colors.brand,
-                onPrimary = colors.textInteractive,
-                secondary = colors.brandSecondary,
-                onSecondary = colors.textInteractive,
-                tertiary = colors.textLink,
-                background = colors.uiBackground,
-                onBackground = colors.textSecondary,
-                surface = colors.uiBackground,
-                onSurface = colors.textSecondary,
-                surfaceVariant = colors.uiFloated,
-                onSurfaceVariant = colors.textHelp,
-                surfaceTint = colors.brand,
-                outline = colors.uiBorder,
-                error = colors.error,
-                onError = colors.textInteractive,
-            )
-        },
-        typography = Typography,
-        shapes = Shapes,
-        content = content,
-    )
+private fun JetsnackPalette(colors: JetsnackColors, content: @Composable () -> Unit) = PreviewThemeOverride(content) { themedContent ->
+    ProvideJetsnackColors(colors) {
+        MaterialTheme(
+            colorScheme = if (colors.isDark) {
+                darkColorScheme(
+                    primary = colors.brand,
+                    onPrimary = colors.textInteractive,
+                    secondary = colors.brandSecondary,
+                    onSecondary = colors.textInteractive,
+                    tertiary = colors.textLink,
+                    background = colors.uiBackground,
+                    onBackground = colors.textSecondary,
+                    surface = colors.uiBackground,
+                    onSurface = colors.textSecondary,
+                    surfaceVariant = colors.uiFloated,
+                    onSurfaceVariant = colors.textHelp,
+                    surfaceTint = colors.brand,
+                    outline = colors.uiBorder,
+                    error = colors.error,
+                    onError = colors.textInteractive,
+                )
+            } else {
+                lightColorScheme(
+                    primary = colors.brand,
+                    onPrimary = colors.textInteractive,
+                    secondary = colors.brandSecondary,
+                    onSecondary = colors.textInteractive,
+                    tertiary = colors.textLink,
+                    background = colors.uiBackground,
+                    onBackground = colors.textSecondary,
+                    surface = colors.uiBackground,
+                    onSurface = colors.textSecondary,
+                    surfaceVariant = colors.uiFloated,
+                    onSurfaceVariant = colors.textHelp,
+                    surfaceTint = colors.brand,
+                    outline = colors.uiBorder,
+                    error = colors.error,
+                    onError = colors.textInteractive,
+                )
+            },
+            typography = Typography,
+            shapes = Shapes,
+            content = themedContent,
+        )
+    }
 }
 
 @ThemeCatalog(name = "Jetsnack · Light", group = "Jetsnack")

--- a/Jetsnack/app/src/main/java/com/example/jetsnack/ui/theme/PreviewTheme.kt
+++ b/Jetsnack/app/src/main/java/com/example/jetsnack/ui/theme/PreviewTheme.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.jetsnack.ui.theme
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.staticCompositionLocalOf
+
+private val LocalPreviewThemeOverride = staticCompositionLocalOf { false }
+
+/** Applies the app theme unless an outer preview catalog has already selected one. */
+@Composable
+internal fun PreviewTheme(content: @Composable () -> Unit, theme: @Composable (@Composable () -> Unit) -> Unit) {
+    if (LocalPreviewThemeOverride.current) content() else theme(content)
+}
+
+/** Applies a catalog theme and prevents nested app-theme calls from replacing it. */
+@Composable
+internal fun PreviewThemeOverride(content: @Composable () -> Unit, theme: @Composable (@Composable () -> Unit) -> Unit) {
+    theme {
+        CompositionLocalProvider(LocalPreviewThemeOverride provides true, content = content)
+    }
+}

--- a/Jetsnack/app/src/main/java/com/example/jetsnack/ui/theme/Theme.kt
+++ b/Jetsnack/app/src/main/java/com/example/jetsnack/ui/theme/Theme.kt
@@ -79,15 +79,17 @@ internal val DarkColorPalette = JetsnackColors(
 
 @Composable
 fun JetsnackTheme(darkTheme: Boolean = isSystemInDarkTheme(), content: @Composable () -> Unit) {
-    val colors = if (darkTheme) DarkColorPalette else LightColorPalette
+    PreviewTheme(content) { themedContent ->
+        val colors = if (darkTheme) DarkColorPalette else LightColorPalette
 
-    ProvideJetsnackColors(colors) {
-        MaterialTheme(
-            colorScheme = debugColors(darkTheme),
-            typography = Typography,
-            shapes = Shapes,
-            content = content,
-        )
+        ProvideJetsnackColors(colors) {
+            MaterialTheme(
+                colorScheme = debugColors(darkTheme),
+                typography = Typography,
+                shapes = Shapes,
+                content = themedContent,
+            )
+        }
     }
 }
 

--- a/Reply/app/src/debug/java/com/example/reply/catalog/ReplyThemeCatalogs.kt
+++ b/Reply/app/src/debug/java/com/example/reply/catalog/ReplyThemeCatalogs.kt
@@ -19,6 +19,7 @@ package com.example.reply.catalog
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.PreviewWrapperProvider
+import com.example.reply.ui.theme.PreviewThemeOverride
 import com.example.reply.ui.theme.darkScheme
 import com.example.reply.ui.theme.highContrastDarkColorScheme
 import com.example.reply.ui.theme.highContrastLightColorScheme
@@ -49,7 +50,9 @@ import ee.schimke.composeai.preview.ThemeCatalog
  * scheme instead of re-entering the contrast selection the catalog is trying to enumerate.
  */
 @Composable private fun ReplyScheme(scheme: androidx.compose.material3.ColorScheme, content: @Composable () -> Unit) =
-    MaterialTheme(colorScheme = scheme, typography = replyTypography, shapes = shapes, content = content)
+    PreviewThemeOverride(content) { themedContent ->
+        MaterialTheme(colorScheme = scheme, typography = replyTypography, shapes = shapes, content = themedContent)
+    }
 
 @ThemeCatalog(name = "Reply · Light", group = "Reply")
 class ReplyLightThemeCatalog : PreviewWrapperProvider {

--- a/Reply/app/src/main/java/com/example/reply/ui/theme/PreviewTheme.kt
+++ b/Reply/app/src/main/java/com/example/reply/ui/theme/PreviewTheme.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.reply.ui.theme
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.staticCompositionLocalOf
+
+private val LocalPreviewThemeOverride = staticCompositionLocalOf { false }
+
+/** Applies the app theme unless an outer preview catalog has already selected one. */
+@Composable
+internal fun PreviewTheme(content: @Composable () -> Unit, theme: @Composable (@Composable () -> Unit) -> Unit) {
+    if (LocalPreviewThemeOverride.current) content() else theme(content)
+}
+
+/** Applies a catalog theme and prevents nested app-theme calls from replacing it. */
+@Composable
+internal fun PreviewThemeOverride(content: @Composable () -> Unit, theme: @Composable (@Composable () -> Unit) -> Unit) {
+    theme {
+        CompositionLocalProvider(LocalPreviewThemeOverride provides true, content = content)
+    }
+}

--- a/Reply/app/src/main/java/com/example/reply/ui/theme/Theme.kt
+++ b/Reply/app/src/main/java/com/example/reply/ui/theme/Theme.kt
@@ -300,18 +300,20 @@ fun ContrastAwareReplyTheme(
     @Composable()
     () -> Unit,
 ) {
-    val replyColorScheme = when {
-        dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
-            val context = LocalContext.current
-            if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
-        }
+    PreviewTheme(content) { themedContent ->
+        val replyColorScheme = when {
+            dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
+                val context = LocalContext.current
+                if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
+            }
 
-        else -> selectSchemeForContrast(darkTheme)
+            else -> selectSchemeForContrast(darkTheme)
+        }
+        MaterialTheme(
+            colorScheme = replyColorScheme,
+            typography = replyTypography,
+            shapes = shapes,
+            content = themedContent,
+        )
     }
-    MaterialTheme(
-        colorScheme = replyColorScheme,
-        typography = replyTypography,
-        shapes = shapes,
-        content = content,
-    )
 }


### PR DESCRIPTION
## What changed

- add an override-aware preview theme helper to each published sample module
- route the app theme through that helper so normal app and IDE previews keep their default theme
- mark `@ThemeCatalog` content as overridden after applying the selected catalog palette, preventing nested app-theme calls from replacing it
- cover JetNews, Jetcaster mobile and Wear, Jetchat, Jetsnack, JetLagged, and Reply

## Why

The preview server accepted theme selections and re-rendered the previews, but the output pixels stayed unchanged. Each preview entered its own app theme inside the catalog wrapper, so the inner theme replaced the selected palette's CompositionLocals.

## Impact

Catalog-selected branded, dynamic, and contrast themes now reach both original source previews and debug catalog previews. Runtime app composition and ordinary previews are unchanged because the override marker defaults to false.

## Validation

- ran each sample's `spotlessApply`
- compiled and discovered previews for all seven modules with `compose-preview list`
- rendered a temporary Jetchat default-versus-dynamic-dark probe through a nested `JetchatTheme`; the images changed from SHA-256 `6c2ef03c…` to `da60cbb1…`
- the full Jetchat render produced 129 Compose PNGs; the two known Glance widget previews remained the only missing outputs and are already excluded by the catalog spec
