### PR TITLE
chore(deps): update compose-ai-tools to 0.19.60

### DIFF
--- a/JetLagged/gradle/libs.versions.toml
+++ b/JetLagged/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-composeAiPreview = "0.19.57"
+composeAiPreview = "0.19.60"
 accompanist = "0.37.3"
 android-material3 = "1.14.0"
 androidGradlePlugin = "9.2.1"

--- a/JetNews/gradle/libs.versions.toml
+++ b/JetNews/gradle/libs.versions.toml
@@ -4,7 +4,7 @@
 #####
 [versions]
 accompanist = "0.37.3"
-composeAiPreview = "0.19.57"
+composeAiPreview = "0.19.60"
 android-material3 = "1.14.0"
 androidGradlePlugin = "9.2.1"
 androidx-activity-compose = "1.13.0"

--- a/Jetcaster/gradle/libs.versions.toml
+++ b/Jetcaster/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 # Do not add a dependency to an individual sample, edit the global version instead.
 #####
 [versions]
-composeAiPreview = "0.19.57"
+composeAiPreview = "0.19.60"
 accompanist = "0.37.3"
 android-material3 = "1.14.0"
 androidGradlePlugin = "9.2.1"

--- a/Jetchat/gradle/libs.versions.toml
+++ b/Jetchat/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 # Do not add a dependency to an individual sample, edit the global version instead.
 #####
 [versions]
-composeAiPreview = "0.19.57"
+composeAiPreview = "0.19.60"
 accompanist = "0.37.3"
 android-material3 = "1.14.0"
 androidGradlePlugin = "9.2.1"

--- a/Jetsnack/gradle/libs.versions.toml
+++ b/Jetsnack/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-composeAiPreview = "0.19.57"
+composeAiPreview = "0.19.60"
 accompanist = "0.37.3"
 android-material3 = "1.14.0"
 androidGradlePlugin = "9.2.1"

--- a/Reply/gradle/libs.versions.toml
+++ b/Reply/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 # Do not add a dependency to an individual sample, edit the global version instead.
 #####
 [versions]
-composeAiPreview = "0.19.57"
+composeAiPreview = "0.19.60"
 accompanist = "0.37.3"
 android-material3 = "1.14.0"
 androidGradlePlugin = "9.2.1"


### PR DESCRIPTION
Bumps `composeAiPreview` **0.19.57 → 0.19.60** in all six sample catalogs: Jetsnack, Reply, Jetcaster, Jetchat, JetLagged, JetNews.

`design-artifacts.yml` tracks `design-artifacts-reusable.yml@main`, so the version catalogs are the only pinned surface here.

## Test plan

- [ ] The design-artifacts run on merge republishes all six catalogs; component counts should be unchanged from the 0.19.57 renders.

Version-catalog only — no source changed, so there is no authored before/after to embed. Render drift, if any, shows up in the CI preview-diff.

---
_Generated by [Claude Code](https://claude.ai/code/session_01141C3L3ahTgzWxEvjWBF7U)_