### PR TITLE
chore(deps): update compose-ai-tools to 1.9.0

### DIFF
--- a/JetLagged/gradle/libs.versions.toml
+++ b/JetLagged/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-composeAiPreview = "1.8.0"
+composeAiPreview = "1.9.0"
 accompanist = "0.37.3"
 android-material3 = "1.14.0"
 androidGradlePlugin = "9.2.1"

--- a/JetNews/gradle/libs.versions.toml
+++ b/JetNews/gradle/libs.versions.toml
@@ -4,7 +4,7 @@
 #####
 [versions]
 accompanist = "0.37.3"
-composeAiPreview = "1.8.0"
+composeAiPreview = "1.9.0"
 android-material3 = "1.14.0"
 androidGradlePlugin = "9.2.1"
 androidx-activity-compose = "1.13.0"

--- a/Jetcaster/gradle/libs.versions.toml
+++ b/Jetcaster/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 # Do not add a dependency to an individual sample, edit the global version instead.
 #####
 [versions]
-composeAiPreview = "1.8.0"
+composeAiPreview = "1.9.0"
 accompanist = "0.37.3"
 android-material3 = "1.14.0"
 androidGradlePlugin = "9.2.1"

--- a/Jetchat/gradle/libs.versions.toml
+++ b/Jetchat/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 # Do not add a dependency to an individual sample, edit the global version instead.
 #####
 [versions]
-composeAiPreview = "1.8.0"
+composeAiPreview = "1.9.0"
 accompanist = "0.37.3"
 android-material3 = "1.14.0"
 androidGradlePlugin = "9.2.1"

--- a/Jetsnack/gradle/libs.versions.toml
+++ b/Jetsnack/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-composeAiPreview = "1.8.0"
+composeAiPreview = "1.9.0"
 accompanist = "0.37.3"
 android-material3 = "1.14.0"
 androidGradlePlugin = "9.2.1"

--- a/Reply/gradle/libs.versions.toml
+++ b/Reply/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 # Do not add a dependency to an individual sample, edit the global version instead.
 #####
 [versions]
-composeAiPreview = "1.8.0"
+composeAiPreview = "1.9.0"
 accompanist = "0.37.3"
 android-material3 = "1.14.0"
 androidGradlePlugin = "9.2.1"


### PR DESCRIPTION
Updates the Compose preview Gradle plugin and preview annotations from 1.8.0 to 1.9.0 across all six published sample catalogs.

Validation:
- compose-preview 1.9.0 discovery succeeded for JetNews (105), Jetchat (129), Jetsnack (173), JetLagged (93), Reply (67), and Jetcaster (166 repository-wide across mobile/Wear/TV).
- Current explicit module selectors are complete for the five single-app builds.
- Jetcaster repository-wide discovery finds 36 previews beyond `:mobile`, but `modules: all` cannot be adopted while these catalogs require `publish-live-bundle: true`; tracked upstream in yschimke/compose-ai-tools#4054.
- `git diff --check` passes.

The design-artifacts workflow will be dispatched after this lands on `previews` to regenerate the catalogs.