### PR TITLE
feat(jetcaster): publish all live modules

### DIFF
--- a/.github/workflows/design-artifacts.yml
+++ b/.github/workflows/design-artifacts.yml
@@ -183,7 +183,9 @@ jobs:
           - system: jetcaster
             spec: Jetcaster/catalog.spec.json
             dir: Jetcaster
-            module: ':mobile'
+            # Publish every preview-enabled module into one live catalog. Keep the
+            # dedicated jetcaster-wear entry below as a stable existing URL.
+            modules: all
             foldArtifact: compose-m3-jetcaster
           - system: jetchat
             spec: Jetchat/catalog.spec.json
@@ -218,7 +220,8 @@ jobs:
     with:
       system: ${{ matrix.system }}
       spec: ${{ matrix.spec }}
-      module: ${{ matrix.module }}
+      module: ${{ matrix.module || '' }}
+      modules: ${{ matrix.modules || '' }}
       working-directory: ${{ matrix.dir }}
       # Render `previews`, the branch the catalogs live on — not whatever ref
       # triggered this. Only matters for triggers that can't imply the ref: a


### PR DESCRIPTION
## Summary

- change the main Jetcaster Design Artifacts catalog from the explicit `:mobile` module to `modules: all`
- pass the repository-wide module selector through the matrix to the reusable workflow
- retain the dedicated `jetcaster-wear` catalog and URL for compatibility

## Why

Jetcaster has preview-enabled mobile, Wear, and TV modules. The main catalog currently renders only `:mobile`, leaving the TV preview out and requiring separate module selection. compose-ai-tools 1.11.0 adds one namespaced executable live bundle per discovered module, so repository-wide coverage no longer requires giving up live rerendering.

## Impact

After this merges to `previews`, the branch push automatically runs Design Artifacts. The `jetcaster` delivery branch should contain mobile, Wear, and TV previews with module-aware live bundles and per-preview splits. The existing `jetcaster-wear` branch remains available.

## Rollout prerequisites verified

- compose-ai-tools #4080 and the corrected driver pin are merged
- compose-ai-tools `v1.11.0` is published and carries the Maven readiness marker
- `preview.coo.ee` is serving `1.11.0`; all 22 configured catalogs currently load with zero load failures

## Validation

- parsed `.github/workflows/design-artifacts.yml` as YAML
- `git diff --check`

Closes yschimke/compose-ai-tools#4054
