### PR TITLE
fix(jetcaster): distinguish preview devices

### DIFF
--- a/Jetcaster/catalog.spec.json
+++ b/Jetcaster/catalog.spec.json
@@ -14,6 +14,38 @@
   ],
   "breakpoints": [
     {
+      "size": "smallPhone",
+      "device": "id:pixel_4a"
+    },
+    {
+      "size": "phone",
+      "device": "spec:width=411dp,height=891dp"
+    },
+    {
+      "size": "landscape",
+      "device": "spec:width=640dp,height=360dp,dpi=480"
+    },
+    {
+      "size": "foldable",
+      "device": "spec:width=673dp,height=841dp"
+    },
+    {
+      "size": "tablet",
+      "device": "spec:width=1280dp,height=800dp,dpi=240"
+    },
+    {
+      "size": "smallRound",
+      "device": "id:wearos_small_round"
+    },
+    {
+      "size": "largeRound",
+      "device": "id:wearos_large_round"
+    },
+    {
+      "size": "activity",
+      "device": "spec:width=900dp,height=760dp,dpi=160"
+    },
+    {
       "size": "compact",
       "widthDp": 412
     },


### PR DESCRIPTION
## What changed

- name every device emitted by Jetcaster's phone, tablet, Wear, and activity previews in `catalog.spec.json`
- keep the existing width-based compact, medium, and expanded breakpoints as fallbacks

## Why

The first repository-wide live-bundle publication reached catalog generation, but `PreviewHome`'s landscape and foldable captures both collapsed to the generic `medium` size axis. The catalog correctly rejected the duplicate output axes instead of overwriting one image with another. Wear's two round devices would have hit the same problem at the generic `compact` axis.

Device-keyed breakpoints use the identity declared by each `@Preview(device = ...)`, so these captures stay distinct even when their widths share a Material window class. This preserves the duplicate-axis safety check and makes future `modules: all` publications deterministic.

Failed rollout: https://github.com/yschimke/compose-samples/actions/runs/32001879469/job/95305395248

## Validation

- `jq empty Jetcaster/catalog.spec.json`
- catalog spec validation against `Jetcaster/mobile` with live-bundle checks enabled: `ok: true`
- direct breakpoint matcher check: all 8 observed device identities resolve to 8 unique size axes
- `git diff --check`
