### PR TITLE
fix(deps): update compose-ai-tools to 1.12.0

### DIFF
--- a/JetLagged/gradle/libs.versions.toml
+++ b/JetLagged/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-composeAiPreview = "1.9.0"
+composeAiPreview = "1.12.0"
 accompanist = "0.37.3"
 android-material3 = "1.14.0"
 androidGradlePlugin = "9.2.1"

--- a/JetNews/gradle/libs.versions.toml
+++ b/JetNews/gradle/libs.versions.toml
@@ -4,7 +4,7 @@
 #####
 [versions]
 accompanist = "0.37.3"
-composeAiPreview = "1.9.0"
+composeAiPreview = "1.12.0"
 android-material3 = "1.14.0"
 androidGradlePlugin = "9.2.1"
 androidx-activity-compose = "1.13.0"

--- a/Jetcaster/gradle/libs.versions.toml
+++ b/Jetcaster/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 # Do not add a dependency to an individual sample, edit the global version instead.
 #####
 [versions]
-composeAiPreview = "1.9.0"
+composeAiPreview = "1.12.0"
 accompanist = "0.37.3"
 android-material3 = "1.14.0"
 androidGradlePlugin = "9.2.1"

--- a/Jetchat/gradle/libs.versions.toml
+++ b/Jetchat/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 # Do not add a dependency to an individual sample, edit the global version instead.
 #####
 [versions]
-composeAiPreview = "1.9.0"
+composeAiPreview = "1.12.0"
 accompanist = "0.37.3"
 android-material3 = "1.14.0"
 androidGradlePlugin = "9.2.1"

--- a/Jetsnack/gradle/libs.versions.toml
+++ b/Jetsnack/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-composeAiPreview = "1.9.0"
+composeAiPreview = "1.12.0"
 accompanist = "0.37.3"
 android-material3 = "1.14.0"
 androidGradlePlugin = "9.2.1"

--- a/Reply/gradle/libs.versions.toml
+++ b/Reply/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 # Do not add a dependency to an individual sample, edit the global version instead.
 #####
 [versions]
-composeAiPreview = "1.9.0"
+composeAiPreview = "1.12.0"
 accompanist = "0.37.3"
 android-material3 = "1.14.0"
 androidGradlePlugin = "9.2.1"


### PR DESCRIPTION
## Summary

Bumps the pinned compose-ai-tools release from **1.9.0 → 1.12.0** across all six sample version catalogs (`composeAiPreview`), which moves both the `ee.schimke.composeai.preview` Gradle plugin and the `preview-annotations` artifact, and — via `cli-version: catalog` in `design-artifacts.yml` — the render CLI behind the published catalogs.

- `JetLagged/gradle/libs.versions.toml`
- `JetNews/gradle/libs.versions.toml`
- `Jetcaster/gradle/libs.versions.toml`
- `Jetchat/gradle/libs.versions.toml`
- `Jetsnack/gradle/libs.versions.toml`
- `Reply/gradle/libs.versions.toml`

The workflow refs here are already `@main`, so nothing else needed changing.

### Preview module scope

Also audited whether this repo is skipping any previews. It is not: each sample has exactly one preview-enabled module (`:app`, or `:mobile`/`:wear` for Jetcaster), every one of them is covered by a matrix entry, and `jetcaster` is already on `modules: all`. No change needed.

## Test plan

Text-only dependency bump — no source or spec changes, so there is no before/after visual to embed here. The rendered output does move with the renderer, and that is covered by `design-artifacts.yml`, which re-renders and republishes every delivery branch on push to `previews` whenever `*/gradle/libs.versions.toml` changes. CI on this PR plus that republish is the verification.

---
_Generated by [Claude Code](https://claude.ai/code/session_015WA5cgxHyG8n5wgaLVKVV3)_