### PR TITLE
chore(deps): compose-ai-tools 1.21.0, and pool the split classpath

### DIFF
--- a/.github/workflows/design-artifacts.yml
+++ b/.github/workflows/design-artifacts.yml
@@ -245,7 +245,13 @@ jobs:
       # classpath — is the right tier here.
       publish-live-bundle: true
       split-per-preview: true
-      split-mode: full
+      # Shared classpath rather than a self-contained bundle per preview:
+      # `classes/app.jar` is published once into `bundle/res` and each split manifest
+      # carries a hash-verified `externalClasspath`, so the live re-render lane is
+      # intact while the delivery branch stops carrying the same jar N times (a
+      # `full` split grows with the preview count on every publish — see
+      # yschimke/compose-ai-tools#4211).
+      split-mode: full-shared-classpath
       # Phone/tablet apps fold in their re-themed mobile M3 section. Wear is a
       # distinct design system with different theme locals and role names, so
       # its matrix entry deliberately leaves this empty.

--- a/JetLagged/gradle/libs.versions.toml
+++ b/JetLagged/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-composeAiPreview = "1.12.0"
+composeAiPreview = "1.21.0"
 accompanist = "0.37.3"
 android-material3 = "1.14.0"
 androidGradlePlugin = "9.2.1"

--- a/JetNews/gradle/libs.versions.toml
+++ b/JetNews/gradle/libs.versions.toml
@@ -4,7 +4,7 @@
 #####
 [versions]
 accompanist = "0.37.3"
-composeAiPreview = "1.12.0"
+composeAiPreview = "1.21.0"
 android-material3 = "1.14.0"
 androidGradlePlugin = "9.2.1"
 androidx-activity-compose = "1.13.0"

--- a/Jetcaster/gradle/libs.versions.toml
+++ b/Jetcaster/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 # Do not add a dependency to an individual sample, edit the global version instead.
 #####
 [versions]
-composeAiPreview = "1.12.0"
+composeAiPreview = "1.21.0"
 accompanist = "0.37.3"
 android-material3 = "1.14.0"
 androidGradlePlugin = "9.2.1"

--- a/Jetchat/gradle/libs.versions.toml
+++ b/Jetchat/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 # Do not add a dependency to an individual sample, edit the global version instead.
 #####
 [versions]
-composeAiPreview = "1.12.0"
+composeAiPreview = "1.21.0"
 accompanist = "0.37.3"
 android-material3 = "1.14.0"
 androidGradlePlugin = "9.2.1"

--- a/Jetsnack/gradle/libs.versions.toml
+++ b/Jetsnack/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-composeAiPreview = "1.12.0"
+composeAiPreview = "1.21.0"
 accompanist = "0.37.3"
 android-material3 = "1.14.0"
 androidGradlePlugin = "9.2.1"

--- a/Reply/gradle/libs.versions.toml
+++ b/Reply/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 # Do not add a dependency to an individual sample, edit the global version instead.
 #####
 [versions]
-composeAiPreview = "1.12.0"
+composeAiPreview = "1.21.0"
 accompanist = "0.37.3"
 android-material3 = "1.14.0"
 androidGradlePlugin = "9.2.1"


### PR DESCRIPTION
## Summary

**compose-ai-tools 1.12.0 → 1.21.0** — `composeAiPreview` in all six sample version catalogs (Jetsnack, Reply, Jetcaster, Jetchat, JetLagged, JetNews). Each drives both `ee.schimke.composeai.preview` and the `preview-annotations` artifact from the same key.

**`split-mode: full` → `full-shared-classpath`** in `.github/workflows/design-artifacts.yml`. A `full` split copies `classes/app.jar` into every per-preview bundle, so each `design-artifacts/<sample>` branch grows with the **preview count** rather than with the backend — and because any catalog edit rewrites `app.jar`, each publish re-writes all N copies and lays down a fresh git delta chain (upstream yschimke/compose-ai-tools#4211).

`full-shared-classpath` publishes `app.jar` once under `bundle/res/<sha256>` and records a hash-verified `externalClasspath` in each split manifest instead. **The live re-render lane is unaffected**: a trusted serve host fetches and verifies the pooled JAR once, hydrates a cached copy of each requested bundle, and starts the daemon from that. The cost is that a bare per-preview download is no longer offline-executable on its own, which is documented upstream in `docs/portable-bundles.md`.

Part of a coordinated bump across the compose-ai-tools consumer repos.

## Test plan

- The edited workflow parses as YAML; the version-catalog edits are single-key value changes.
- `--shared-classpath-out` has been in the CLI since 0.19.58, so 1.21.0 carries it comfortably.
- The published catalogs are regenerated by `design-artifacts.yml`; the pooled `bundle/res` + per-manifest `externalClasspath` appear on the next run.

> **Note on timing.** `yschimke/compose-ai-tools` cut 1.21.0 at 20:09 UTC; for a few minutes afterwards the `ee.schimke.composeai:*:1.21.0` artifacts 404'd on Maven Central while the sync completed, which failed Gradle-configuring jobs across this batch of PRs. Maven Central now serves `<release>1.21.0</release>`.